### PR TITLE
64 some event page summary stats are incorrect

### DIFF
--- a/client/src/pages/Events/Events.tsx
+++ b/client/src/pages/Events/Events.tsx
@@ -66,7 +66,7 @@ export function Events() {
                 date={event.dateDisplay}
                 time={event.time}
                 location={event.mainLocation}
-                participants={event.numtotalParticipants}
+                participants={event.numTotalParticipants}
                 drivers={event.numDrivers}
                 packers={event.numPackers}
               />

--- a/client/src/pages/ViewEvent/ViewEvent.tsx
+++ b/client/src/pages/ViewEvent/ViewEvent.tsx
@@ -124,7 +124,7 @@ export const ViewEvent = () => {
           />
           <HeaderValueDisplay
             header="Total Participants"
-            value={event.numtotalParticipants}
+            value={event.numTotalParticipants}
           />
         </div>
         <div className="h-12" />

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -6,7 +6,7 @@ export interface ProcessedEvent {
   mainLocation: string;
   numDrivers: number;
   numPackers: number;
-  numtotalParticipants: number;
+  numTotalParticipants: number;
   numOnlyDrivers: number;
   numOnlyPackers: number;
   numBothDriversAndPackers: number;

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -71,16 +71,18 @@ function processGeneralEventData(event: Record<Event>): ProcessedEvent {
 
   const numDrivers = event.fields["Total Count of Drivers for Event"] || 0; // number of total drivers for event
   const numPackers = event.fields["Total Count of Distributors for Event"] || 0; // number of total packers for event
+
   const numOnlyDrivers =
     event.fields["Only Driver Count Including Unconfirmed"] || 0; // number of only drivers for event
 
-  console.log(event.fields);
   const numOnlyPackers =
     event.fields["Only Distributor Count Including Unconfirmed"] || 0; // number of only packers for event
+
   const numTotalParticipants =
     event.fields["Total Count of Volunteers for Event"] || 0; // number of total participants for event
-  const numDrivingAndPacking =
-    event.fields["Driver and Distributor Count"] || 0; // number of total participants for event
+
+  const numDriversAndPackers =
+    event.fields["Driver and Distributor Count Including Unconfirmed"] || 0; // all driver and distr participants for event
 
   return {
     id: event.id,
@@ -99,7 +101,7 @@ function processGeneralEventData(event: Record<Event>): ProcessedEvent {
     numSpecialGroups: 0, // number of associated special groups
     numOnlyDrivers: numOnlyDrivers,
     numOnlyPackers: numOnlyPackers,
-    numBothDriversAndPackers: numDrivingAndPacking, // number of both drivers and packers
+    numBothDriversAndPackers: numDriversAndPackers, // number of both drivers and packers
     scheduledSlots: event.fields["📅 Scheduled Slots"] || [],
     supplierId: event.fields.Supplier
       ? event.fields.Supplier[0]
@@ -159,6 +161,7 @@ router.route("/api/events").get(
       `&fields=Only Driver Count` + // People only driving
       `&fields=Only Distributor Count Including Unconfirmed` + // People only packing including unconfirmed
       `&fields=Only Driver Count Including Unconfirmed` + // People only driving including unconfirmed
+      `&fields=Driver and Distributor Count Including Unconfirmed` + // People both driving and packing including unconfirmed
       `&fields=Only Distributor Count` + // People only packing
       `&fields=Driver and Distributor Count` + // People both driving and packing
       `&fields=Total Count of Volunteers for Event` + // Total Participants

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -1,13 +1,13 @@
 import express from "express";
 import asyncHandler from "express-async-handler";
-import {protect} from "../middleware/authMiddleware";
-import {Request, Response} from "express";
+import { protect } from "../middleware/authMiddleware";
+import { Request, Response } from "express";
 import {
   airtableGET,
   AIRTABLE_ERROR_MESSAGE,
   AIRTABLE_URL_BASE,
 } from "../httpUtils/airtable";
-import {fetch} from "../httpUtils/nodeFetch";
+import { fetch } from "../httpUtils/nodeFetch";
 //Status codes
 import {
   INTERNAL_SERVER_ERROR,
@@ -24,7 +24,7 @@ import {
   ProcessedSpecialEvent,
 } from "../types";
 //Logger
-import {logger} from "../loggerUtils/logger";
+import { logger } from "../loggerUtils/logger";
 import dotenv from "dotenv";
 
 const router = express.Router();
@@ -69,14 +69,10 @@ function processGeneralEventData(event: Record<Event>): ProcessedEvent {
 
   const eventDate = new Date(event.fields["Start Time"]);
 
-  const numDrivers =
-    event.fields["Total Count of Drivers for Event"] || 0; // number of total drivers for event
-  const numPackers =
-    event.fields["Total Count of Distributors for Event"] || 0; // number of total packers for event
-  const numOnlyDrivers =
-    event.fields["Only Driver Count"] || 0; // number of only drivers for event
-  const numOnlyPackers =
-    event.fields["Only Distributor Count"] || 0; // number of only packers for event
+  const numDrivers = event.fields["Total Count of Drivers for Event"] || 0; // number of total drivers for event
+  const numPackers = event.fields["Total Count of Distributors for Event"] || 0; // number of total packers for event
+  const numOnlyDrivers = event.fields["Only Driver Count"] || 0; // number of only drivers for event
+  const numOnlyPackers = event.fields["Only Distributor Count"] || 0; // number of only packers for event
   const numTotalParticipants =
     event.fields["Total Count of Volunteers for Event"] || 0; // number of total participants for event
   const numDrivingAndPacking =
@@ -95,7 +91,7 @@ function processGeneralEventData(event: Record<Event>): ProcessedEvent {
       : "No address", // event pickup location
     numDrivers: numDrivers,
     numPackers: numPackers,
-    numtotalParticipants: numTotalParticipants,
+    numTotalParticipants: numTotalParticipants,
     numSpecialGroups: 0, // number of associated special groups
     numOnlyDrivers: numOnlyDrivers,
     numOnlyPackers: numOnlyPackers,
@@ -164,7 +160,7 @@ router.route("/api/events").get(
       `&fields=Supplier` +
       `&fields=📅 Scheduled Slots`; //Scheduled slots -> list of participants for event
 
-    const futureEventsAirtableResp = await airtableGET<Event>({url: url});
+    const futureEventsAirtableResp = await airtableGET<Event>({ url: url });
 
     //An event is invalid if it has no start time
     let futureEventsData = futureEventsAirtableResp.records.filter(
@@ -194,7 +190,7 @@ router.route("/api/events").get(
           se.fields["Total Count of Drivers for Event"] || 0;
         processedGeneralEvent.numPackers +=
           se.fields["Total Count of Distributors for Event"] || 0;
-        processedGeneralEvent.numtotalParticipants +=
+        processedGeneralEvent.numTotalParticipants +=
           se.fields["Total Count of Volunteers for Event"] || 0;
         processedGeneralEvent.numBothDriversAndPackers +=
           se.fields["Driver and Distributor Count"] || 0;
@@ -219,7 +215,7 @@ router.route("/api/events").get(
 router.route("/api/events/view-event-special-groups/").get(
   protect,
   asyncHandler(async (req: Request, res: Response) => {
-    const {eventIds} = req.query;
+    const { eventIds } = req.query;
     logger.info(
       `GET /api/events/view-event-special-groups/?eventIds=${eventIds}`
     );
@@ -241,7 +237,7 @@ router.route("/api/events/view-event-special-groups/").get(
       `&fields=Volunteer Group` + // Special Group
       `&fields=Shortened Link to Special Event Signup Form`; // Special Event Link
 
-    const specialEvents = await airtableGET<SpecialEvent>({url: url});
+    const specialEvents = await airtableGET<SpecialEvent>({ url: url });
 
     let processedSpecialEvents: ProcessedSpecialEvent[] =
       specialEvents.records.map((specialEvent) => {

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -31,7 +31,7 @@ const router = express.Router();
 dotenv.config();
 
 let today = "TODAY()";
-if (process.env.NODE_ENV === "dev" && process.env.TODAY) {
+if (process.env.NODE_ENV === "development" && process.env.TODAY) {
   today = `"${process.env.TODAY}"`;
 }
 

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -71,8 +71,10 @@ function processGeneralEventData(event: Record<Event>): ProcessedEvent {
 
   const numDrivers = event.fields["Total Count of Drivers for Event"] || 0; // number of total drivers for event
   const numPackers = event.fields["Total Count of Distributors for Event"] || 0; // number of total packers for event
-  const numOnlyDrivers = event.fields["Only Driver Count"] || 0; // number of only drivers for event
-  const numOnlyPackers = event.fields["Only Distributor Count"] || 0; // number of only packers for event
+  const numOnlyDrivers =
+    event.fields["Only Driver Count Including Unconfirmed"] || 0; // number of only drivers for event
+  const numOnlyPackers =
+    event.fields["Only Distributor Count Including Unconfirmed"] || 0; // number of only packers for event
   const numTotalParticipants =
     event.fields["Total Count of Volunteers for Event"] || 0; // number of total participants for event
   const numDrivingAndPacking =

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -73,6 +73,8 @@ function processGeneralEventData(event: Record<Event>): ProcessedEvent {
   const numPackers = event.fields["Total Count of Distributors for Event"] || 0; // number of total packers for event
   const numOnlyDrivers =
     event.fields["Only Driver Count Including Unconfirmed"] || 0; // number of only drivers for event
+
+  console.log(event.fields);
   const numOnlyPackers =
     event.fields["Only Distributor Count Including Unconfirmed"] || 0; // number of only packers for event
   const numTotalParticipants =
@@ -155,6 +157,8 @@ router.route("/api/events").get(
       `&fields=Total Count of Distributors for Event` + // Packers
       `&fields=Total Count of Drivers for Event` + // Drivers
       `&fields=Only Driver Count` + // People only driving
+      `&fields=Only Distributor Count Including Unconfirmed` + // People only packing including unconfirmed
+      `&fields=Only Driver Count Including Unconfirmed` + // People only driving including unconfirmed
       `&fields=Only Distributor Count` + // People only packing
       `&fields=Driver and Distributor Count` + // People both driving and packing
       `&fields=Total Count of Volunteers for Event` + // Total Participants

--- a/server/types.ts
+++ b/server/types.ts
@@ -35,7 +35,7 @@ export interface ProcessedEvent {
   mainLocation: string;
   numDrivers: number;
   numPackers: number;
-  numtotalParticipants: number;
+  numTotalParticipants: number;
   numOnlyDrivers: number;
   numOnlyPackers: number;
   numBothDriversAndPackers: number;

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,6 +1,7 @@
 export interface AirtableResponse<T> {
   records: Record<T>[];
 }
+
 export interface Record<T> {
   id: string;
   fields: T;
@@ -18,6 +19,9 @@ export interface Event {
   "Total Count of Drivers for Event": number | undefined;
   "Total Count of Distributors for Event": number | undefined;
   "Total Count of Volunteers for Event": number | undefined;
+  "Driver and Distributor Count": number | undefined;
+  "Only Driver Count": number | undefined;
+  "Only Distributor Count": number | undefined;
   "Special Event": boolean | undefined;
   Supplier: string[] | undefined;
   "📅 Scheduled Slots": string[] | undefined;

--- a/server/types.ts
+++ b/server/types.ts
@@ -22,6 +22,8 @@ export interface Event {
   "Driver and Distributor Count": number | undefined;
   "Only Driver Count": number | undefined;
   "Only Distributor Count": number | undefined;
+  "Only Driver Count Including Unconfirmed": number | undefined;
+  "Only Distributor Count Including Unconfirmed": number | undefined;
   "Special Event": boolean | undefined;
   Supplier: string[] | undefined;
   "📅 Scheduled Slots": string[] | undefined;

--- a/server/types.ts
+++ b/server/types.ts
@@ -24,6 +24,7 @@ export interface Event {
   "Only Distributor Count": number | undefined;
   "Only Driver Count Including Unconfirmed": number | undefined;
   "Only Distributor Count Including Unconfirmed": number | undefined;
+  "Driver and Distributor Count Including Unconfirmed": number | undefined;
   "Special Event": boolean | undefined;
   Supplier: string[] | undefined;
   "📅 Scheduled Slots": string[] | undefined;


### PR DESCRIPTION
Addresses #64 

- Explicitly getting this data from airtable now to fix the discrepancies
-  Renamed a variable to match style

Looking at 02/11/2023

<img width="1424" alt="image" src="https://github.com/grassrootsgrocery/admin-portal/assets/30198937/81823050-a308-451a-ab5a-4e683bd4d40e">

<img width="922" alt="image" src="https://github.com/grassrootsgrocery/admin-portal/assets/30198937/c97d605b-0983-4d97-ae29-e94442a1cdaa">


Looking at 03/04/2023

<img width="1444" alt="image" src="https://github.com/grassrootsgrocery/admin-portal/assets/30198937/8235b830-e8f1-4203-b4b3-0fc9af8cfbf1">


<img width="835" alt="image" src="https://github.com/grassrootsgrocery/admin-portal/assets/30198937/71303484-c6a2-44b0-852f-47090587a67a">

A more recent event, 06/10/2023

<img width="1445" alt="image" src="https://github.com/grassrootsgrocery/admin-portal/assets/30198937/8a7a47c2-90f4-4cfd-b0da-798c600f9aa3">


<img width="849" alt="image" src="https://github.com/grassrootsgrocery/admin-portal/assets/30198937/36bd223e-2f4c-4121-9907-30169e8cea36">
