### PR TITLE
52 ask for confirmation password for triggering automations

### DIFF
--- a/client/src/pages/ViewEvent/Messaging.tsx
+++ b/client/src/pages/ViewEvent/Messaging.tsx
@@ -68,18 +68,23 @@ function PreMessagePopupButton(props: PreMessagePopupButtonProps) {
               ? "Last messages sent:"
               : "Are you sure you want to send this message?"}
           </p>
-          {lastMessagesSent.data?.map((message: ProcessedTextAutomation) => (
-            <div className="flex flex-col items-start gap-2 text-base lg:text-xl">
-              <p className="font-semibold text-newLeafGreen">
-                {message["Text Type"]}
-              </p>
-              <p className="text-sm text-gray-500">
-                {`Sent by ${message["Triggered by"]} from the number ${
-                  message["Sent by"]
-                } on ${new Date(message["Date"]).toLocaleDateString()}`}
-              </p>
-            </div>
-          ))}
+          {lastMessagesSent.data?.map(
+            (message: ProcessedTextAutomation, index: number) => (
+              <div
+                key={index}
+                className="flex flex-col items-start gap-2 text-base lg:text-xl"
+              >
+                <p className="font-semibold text-newLeafGreen">
+                  {message["Text Type"]}
+                </p>
+                <p className="text-sm text-gray-500">
+                  {`Sent by ${message["Triggered by"]} from the number ${
+                    message["Sent by"]
+                  } on ${new Date(message["Date"]).toLocaleDateString()}`}
+                </p>
+              </div>
+            )
+          )}
 
           <div className="row-auto flex justify-center space-x-2">
             <Modal.Close className="rounded-full bg-red-700 px-2 py-1 text-xs font-semibold text-white shadow-sm shadow-newLeafGreen outline-none transition-all hover:-translate-y-0.5 hover:shadow-md hover:shadow-newLeafGreen md:px-4 md:py-2 lg:text-base">
@@ -233,10 +238,7 @@ export function Messaging() {
           <PreMessagePopupButton
             buttonText={"Recruit Coordinators"}
             token={token}
-            onClick={() => {
-              console.log("sending to coordinators");
-              //recruitCoordinators.mutate()
-            }}
+            onClick={() => recruitCoordinators.mutate()}
           />
         </div>
         {/* Participants RecruitmentCard */}
@@ -256,10 +258,7 @@ export function Messaging() {
           <PreMessagePopupButton
             buttonText={"Recruit Volunteers"}
             token={token}
-            onClick={() => {
-              console.log("ending to volunteers");
-              //recruitVolunteers.mutate()
-            }}
+            onClick={() => recruitVolunteers.mutate()}
           />
         </div>
       </div>

--- a/client/src/pages/ViewEvent/Messaging.tsx
+++ b/client/src/pages/ViewEvent/Messaging.tsx
@@ -69,8 +69,8 @@ function PreMessagePopupButton(props: PreMessagePopupButtonProps) {
               : "Are you sure you want to send this message?"}
           </p>
           {lastMessagesSent.data?.length
-            ? lastMessagesSent.data
-                ?.sort((a, b) => {
+            ? [...lastMessagesSent.data]
+                .sort((a, b) => {
                   return (
                     new Date(b["Date"]).getTime() -
                     new Date(a["Date"]).getTime()

--- a/client/src/pages/ViewEvent/Messaging.tsx
+++ b/client/src/pages/ViewEvent/Messaging.tsx
@@ -87,9 +87,7 @@ function PreMessagePopupButton(props: PreMessagePopupButtonProps) {
             </Modal.Close>
             <Modal.Close
               className="rounded-full bg-newLeafGreen px-2 py-1 text-xs font-semibold text-white shadow-sm shadow-newLeafGreen outline-none transition-all hover:-translate-y-0.5 hover:shadow-md hover:shadow-newLeafGreen md:px-4 md:py-2 lg:text-base"
-              onClick={() => {
-                console.log("sending");
-              }}
+              onClick={props.onClick}
             >
               Confirm Send
             </Modal.Close>
@@ -232,9 +230,14 @@ export function Messaging() {
               readOnly
             />
           )}
-          <button className={btn} onClick={() => recruitCoordinators.mutate()}>
-            Recruit Coordinators
-          </button>
+          <PreMessagePopupButton
+            buttonText={"Recruit Coordinators"}
+            token={token}
+            onClick={() => {
+              console.log("sending to coordinators");
+              //recruitCoordinators.mutate()
+            }}
+          />
         </div>
         {/* Participants RecruitmentCard */}
         <div className={recruitCard}>
@@ -250,13 +253,11 @@ export function Messaging() {
               readOnly
             />
           )}
-
           <PreMessagePopupButton
             buttonText={"Recruit Volunteers"}
             token={token}
             onClick={() => {
-              console.log("hi");
-
+              console.log("ending to volunteers");
               //recruitVolunteers.mutate()
             }}
           />

--- a/client/src/pages/ViewEvent/Messaging.tsx
+++ b/client/src/pages/ViewEvent/Messaging.tsx
@@ -4,8 +4,12 @@ import { API_BASE_URL } from "../../httpUtils";
 //Assets
 import recruitment from "../../assets/recruitment.svg";
 import { useAuth } from "../../contexts/AuthContext";
+import * as Dialog from "@radix-ui/react-dialog";
 import { Navigate } from "react-router-dom";
 import { toastNotify } from "../../uiUtils";
+import { ProcessedTextAutomation } from "../../types";
+import { Popup } from "../../components/Popup";
+import { MouseEventHandler } from "react";
 
 // Tailwind classes
 const sectionHeader =
@@ -18,6 +22,69 @@ const textArea =
   "grow overflow-scroll w-full resize-none rounded-md border-4 border-softGrayWhite py-2 px-4 text-base lg:text-xl";
 const btn =
   "rounded-full bg-pumpkinOrange px-3 py-2 text-sm font-semibold text-white lg:px-5 lg:py-3 lg:text-base lg:font-bold lg:shadow-md lg:shadow-newLeafGreen lg:transition-all lg:hover:-translate-y-1 lg:hover:shadow-lg lg:hover:shadow-newLeafGreen";
+
+interface PreMessagePopupButtonProps {
+  buttonText: string;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+  token: string;
+}
+
+function PreMessagePopupButton(props: PreMessagePopupButtonProps) {
+  // Last messages sent
+  const lastMessagesSent = useQuery(
+    ["fetchLastMessagesSent"],
+    async (): Promise<ProcessedTextAutomation[]> => {
+      const resp = await fetch(
+        `${API_BASE_URL}/api/messaging/last-texts-sent`,
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${props.token}`,
+          },
+        }
+      );
+      if (!resp.ok) {
+        const data = await resp.json();
+        throw new Error(data.message);
+      }
+
+      const text = resp.json();
+      console.log(text);
+      return text;
+    }
+  );
+
+  return lastMessagesSent.isLoading ? (
+    <Loading size={"medium"} thickness={"thicc"} />
+  ) : (
+    <Popup
+      trigger={<button className={btn}>{props.buttonText}</button>}
+      content={
+        // if there was a message sent in the last 7 days show the name of it, who sent it
+        // and when it was sent, otherwise just ask are you sure you want to send
+        // this message
+
+        <div className="flex flex-col gap-4">
+          <p className="text-xl font-semibold text-newLeafGreen">
+            {lastMessagesSent.data?.length
+              ? "Last messages sent:"
+              : "Are you sure you want to send this message?"}
+          </p>
+          {lastMessagesSent.data?.map((message: ProcessedTextAutomation) => (
+            <div className="flex flex-col items-start gap-2 text-base lg:text-xl">
+              <p className="font-semibold text-newLeafGreen">
+                {message["Text Type"]}
+              </p>
+              <p className="text-sm text-gray-500">
+                {`Sent by ${message["Sent by"]} on ${message["Date"]}`}
+              </p>
+            </div>
+          ))}
+        </div>
+      }
+    />
+  );
+}
 
 export function Messaging() {
   const { token } = useAuth();
@@ -169,9 +236,16 @@ export function Messaging() {
               readOnly
             />
           )}
-          <button className={btn} onClick={() => recruitVolunteers.mutate()}>
-            Recruit Participants
-          </button>
+
+          <PreMessagePopupButton
+            buttonText={"Recruit Volunteers"}
+            token={token}
+            onClick={() => {
+              console.log("hi");
+
+              //recruitVolunteers.mutate()
+            }}
+          />
         </div>
       </div>
     </div>

--- a/client/src/pages/ViewEvent/Messaging.tsx
+++ b/client/src/pages/ViewEvent/Messaging.tsx
@@ -68,23 +68,23 @@ function PreMessagePopupButton(props: PreMessagePopupButtonProps) {
               ? "Last messages sent:"
               : "Are you sure you want to send this message?"}
           </p>
-          {lastMessagesSent.data?.map(
-            (message: ProcessedTextAutomation, index: number) => (
-              <div
-                key={index}
-                className="flex flex-col items-start gap-2 text-base lg:text-xl"
-              >
-                <p className="font-semibold text-newLeafGreen">
-                  {message["Text Type"]}
-                </p>
-                <p className="text-sm text-gray-500">
-                  {`Sent by ${message["Triggered by"]} from the number ${
-                    message["Sent by"]
-                  } on ${new Date(message["Date"]).toLocaleDateString()}`}
-                </p>
-              </div>
-            )
-          )}
+          {lastMessagesSent.data?.length
+            ? lastMessagesSent.data?.map((message, index) => (
+                <div
+                  key={index}
+                  className="flex flex-col items-start gap-2 text-base lg:text-xl"
+                >
+                  <p className="font-semibold text-newLeafGreen">
+                    {message["Text Type"]}
+                  </p>
+                  <p className="text-sm text-gray-500">
+                    {`Sent by ${message["Triggered by"]} from the number ${
+                      message["Sent by"]
+                    } on ${new Date(message["Date"]).toLocaleDateString()}`}
+                  </p>
+                </div>
+              ))
+            : null}
 
           <div className="row-auto flex justify-center space-x-2">
             <Modal.Close className="rounded-full bg-red-700 px-2 py-1 text-xs font-semibold text-white shadow-sm shadow-newLeafGreen outline-none transition-all hover:-translate-y-0.5 hover:shadow-md hover:shadow-newLeafGreen md:px-4 md:py-2 lg:text-base">

--- a/client/src/pages/ViewEvent/Messaging.tsx
+++ b/client/src/pages/ViewEvent/Messaging.tsx
@@ -49,7 +49,6 @@ function PreMessagePopupButton(props: PreMessagePopupButtonProps) {
       }
 
       const text = resp.json();
-      console.log(text);
       return text;
     }
   );
@@ -76,7 +75,9 @@ function PreMessagePopupButton(props: PreMessagePopupButtonProps) {
                 {message["Text Type"]}
               </p>
               <p className="text-sm text-gray-500">
-                {`Sent by ${message["Sent by"]} on ${message["Date"]}`}
+                {`Sent by ${message["Triggered by"]} from the number ${
+                  message["Sent by"]
+                } on ${new Date(message["Date"]).toLocaleDateString()}`}
               </p>
             </div>
           ))}

--- a/client/src/pages/ViewEvent/Messaging.tsx
+++ b/client/src/pages/ViewEvent/Messaging.tsx
@@ -72,8 +72,8 @@ function PreMessagePopupButton(props: PreMessagePopupButtonProps) {
             ? [...lastMessagesSent.data]
                 .sort((a, b) => {
                   return (
-                    new Date(b["Date"]).getTime() -
-                    new Date(a["Date"]).getTime()
+                    new Date(a["Date"]).getTime() -
+                    new Date(b["Date"]).getTime()
                   );
                 })
                 .map((message, index) => (

--- a/client/src/pages/ViewEvent/Messaging.tsx
+++ b/client/src/pages/ViewEvent/Messaging.tsx
@@ -4,12 +4,12 @@ import { API_BASE_URL } from "../../httpUtils";
 //Assets
 import recruitment from "../../assets/recruitment.svg";
 import { useAuth } from "../../contexts/AuthContext";
-import * as Dialog from "@radix-ui/react-dialog";
 import { Navigate } from "react-router-dom";
 import { toastNotify } from "../../uiUtils";
 import { ProcessedTextAutomation } from "../../types";
 import { Popup } from "../../components/Popup";
 import { MouseEventHandler } from "react";
+import * as Modal from "@radix-ui/react-dialog";
 
 // Tailwind classes
 const sectionHeader =
@@ -48,8 +48,7 @@ function PreMessagePopupButton(props: PreMessagePopupButtonProps) {
         throw new Error(data.message);
       }
 
-      const text = resp.json();
-      return text;
+      return resp.json();
     }
   );
 
@@ -81,6 +80,20 @@ function PreMessagePopupButton(props: PreMessagePopupButtonProps) {
               </p>
             </div>
           ))}
+
+          <div className="row-auto flex justify-center space-x-2">
+            <Modal.Close className="rounded-full bg-red-700 px-2 py-1 text-xs font-semibold text-white shadow-sm shadow-newLeafGreen outline-none transition-all hover:-translate-y-0.5 hover:shadow-md hover:shadow-newLeafGreen md:px-4 md:py-2 lg:text-base">
+              Cancel Send
+            </Modal.Close>
+            <Modal.Close
+              className="rounded-full bg-newLeafGreen px-2 py-1 text-xs font-semibold text-white shadow-sm shadow-newLeafGreen outline-none transition-all hover:-translate-y-0.5 hover:shadow-md hover:shadow-newLeafGreen md:px-4 md:py-2 lg:text-base"
+              onClick={() => {
+                console.log("sending");
+              }}
+            >
+              Confirm Send
+            </Modal.Close>
+          </div>
         </div>
       }
     />

--- a/client/src/pages/ViewEvent/Messaging.tsx
+++ b/client/src/pages/ViewEvent/Messaging.tsx
@@ -69,21 +69,28 @@ function PreMessagePopupButton(props: PreMessagePopupButtonProps) {
               : "Are you sure you want to send this message?"}
           </p>
           {lastMessagesSent.data?.length
-            ? lastMessagesSent.data?.map((message, index) => (
-                <div
-                  key={index}
-                  className="flex flex-col items-start gap-2 text-base lg:text-xl"
-                >
-                  <p className="font-semibold text-newLeafGreen">
-                    {message["Text Type"]}
-                  </p>
-                  <p className="text-sm text-gray-500">
-                    {`Sent by ${message["Triggered by"]} from the number ${
-                      message["Sent by"]
-                    } on ${new Date(message["Date"]).toLocaleDateString()}`}
-                  </p>
-                </div>
-              ))
+            ? lastMessagesSent.data
+                ?.sort((a, b) => {
+                  return (
+                    new Date(b["Date"]).getTime() -
+                    new Date(a["Date"]).getTime()
+                  );
+                })
+                .map((message, index) => (
+                  <div
+                    key={index}
+                    className="flex flex-col items-start gap-2 text-base lg:text-xl"
+                  >
+                    <p className="font-semibold text-newLeafGreen">
+                      {message["Text Type"]}
+                    </p>
+                    <p className="text-sm text-gray-500">
+                      {`Sent by ${message["Triggered by"]} from the number ${
+                        message["Sent by"]
+                      } on ${new Date(message["Date"]).toLocaleDateString()}`}
+                    </p>
+                  </div>
+                ))
             : null}
 
           <div className="row-auto flex justify-center space-x-2">

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -60,6 +60,15 @@ export interface ProcessedDropoffLocation {
   matchedDrivers: string[];
 }
 
+export interface ProcessedTextAutomation {
+  "Text Type": string;
+  "Sent by": string;
+  "Triggered by": string;
+  "Successful Executions": number;
+  "Failed Executions": number;
+  Date: Date;
+}
+
 export interface ProcessedSpecialGroup {
   id: string;
   name: string;

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -119,11 +119,11 @@ router.route("/api/auth/login").post(
       password,
       user.fields.Password
     );
-    /*    if (!isPasswordCorrect) {
+    if (!isPasswordCorrect) {
       logger.info("Incorrect password");
       res.status(BAD_REQUEST);
       throw new Error("Incorrect credentials");
-    }*/
+    }
     if (!user.id) {
       //Should never happen
       res.status(INTERNAL_SERVER_ERROR);

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -119,11 +119,11 @@ router.route("/api/auth/login").post(
       password,
       user.fields.Password
     );
-    if (!isPasswordCorrect) {
+    /*    if (!isPasswordCorrect) {
       logger.info("Incorrect password");
       res.status(BAD_REQUEST);
       throw new Error("Incorrect credentials");
-    }
+    }*/
     if (!user.id) {
       //Should never happen
       res.status(INTERNAL_SERVER_ERROR);

--- a/server/routes/messaging.ts
+++ b/server/routes/messaging.ts
@@ -215,7 +215,7 @@ router.route("/api/messaging/locations-to-drivers-text").post(
 );
 
 /**
- * @description Start the "[NEW] Send Locations and POC details to volunteer drivers (only text, no email)" Make automation
+ * @description Get the last 7 days of messages sent
  * @route  GET /api/messaging/last-texts-sent
  * @access
  */
@@ -230,6 +230,7 @@ router.route("/api/messaging/last-texts-sent").get(
     const data = await airtableGET<TextAutomation>({ url });
 
     const fields = data.records.map((record) => record.fields);
+
     // only sends fields of each one
     res.status(200).json(fields);
   })

--- a/server/routes/messaging.ts
+++ b/server/routes/messaging.ts
@@ -230,7 +230,6 @@ router.route("/api/messaging/last-texts-sent").get(
     const data = await airtableGET<TextAutomation>({ url });
 
     const fields = data.records.map((record) => record.fields);
-    fields.forEach(console.log);
     // only sends fields of each one
     res.status(200).json(fields);
   })

--- a/server/routes/messaging.ts
+++ b/server/routes/messaging.ts
@@ -220,6 +220,7 @@ router.route("/api/messaging/locations-to-drivers-text").post(
  * @access
  */
 router.route("/api/messaging/last-texts-sent").get(
+  protect,
   asyncHandler(async (req: Request, res: Response) => {
     // get messages sent in last 7 days
     const url =
@@ -228,7 +229,10 @@ router.route("/api/messaging/last-texts-sent").get(
 
     const data = await airtableGET<TextAutomation>({ url });
 
-    res.status(OK).json(data.records);
+    const fields = data.records.map((record) => record.fields);
+    fields.forEach(console.log);
+    // only sends fields of each one
+    res.status(200).json(fields);
   })
 );
 

--- a/server/routes/messaging.ts
+++ b/server/routes/messaging.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import asyncHandler from "express-async-handler";
-import { protect } from "../middleware/authMiddleware";
+import { adminProtect, protect } from "../middleware/authMiddleware";
 import { fetch } from "../httpUtils/nodeFetch";
 //Types
 import { Request, Response } from "express";
@@ -75,7 +75,7 @@ router.route("/api/messaging/coordinator-recruitment-text").get(
  * @access
  */
 router.route("/api/messaging/coordinator-recruitment-text").post(
-  protect,
+  adminProtect,
   asyncHandler(async (req: Request, res: Response) => {
     checkNodeEnvIsProduction(res);
     await makeRequest(
@@ -115,7 +115,7 @@ router.route("/api/messaging/volunteer-recruitment-text").get(
  * @access
  */
 router.route("/api/messaging/volunteer-recruitment-text").post(
-  protect,
+  adminProtect,
   asyncHandler(async (req: Request, res: Response) => {
     checkNodeEnvIsProduction(res);
     await makeRequest(
@@ -199,7 +199,7 @@ router.route("/api/messaging/locations-to-drivers-text").get(
  * @access
  */
 router.route("/api/messaging/locations-to-drivers-text").post(
-  protect,
+  adminProtect,
   asyncHandler(async (req: Request, res: Response) => {
     checkNodeEnvIsProduction(res);
     await makeRequest(

--- a/server/routes/messaging.ts
+++ b/server/routes/messaging.ts
@@ -6,6 +6,8 @@ import { fetch } from "../httpUtils/nodeFetch";
 import { Request, Response } from "express";
 //Status codes
 import { INTERNAL_SERVER_ERROR, OK } from "../httpUtils/statusCodes";
+import { AIRTABLE_URL_BASE, airtableGET } from "../httpUtils/airtable";
+import { TextAutomation } from "../types";
 
 //Utils
 async function makeRequest(
@@ -209,6 +211,24 @@ router.route("/api/messaging/locations-to-drivers-text").post(
       message:
         "'[NEW] Send Locations and POC details to volunteer drivers (only text, no email)' Make automation started.",
     });
+  })
+);
+
+/**
+ * @description Start the "[NEW] Send Locations and POC details to volunteer drivers (only text, no email)" Make automation
+ * @route  GET /api/messaging/last-texts-sent
+ * @access
+ */
+router.route("/api/messaging/last-texts-sent").get(
+  asyncHandler(async (req: Request, res: Response) => {
+    // get messages sent in last 7 days
+    const url =
+      `${AIRTABLE_URL_BASE}/Text Automation History` +
+      `?filterByFormula=DATETIME_DIFF(NOW(), {Date}, 'days') <= 7`;
+
+    const data = await airtableGET<TextAutomation>({ url });
+
+    res.status(OK).json(data.records);
   })
 );
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -30,6 +30,15 @@ export interface Event {
   "📅 Scheduled Slots": string[] | undefined;
 }
 
+export interface TextAutomation {
+  "Text Type": string;
+  "Sent by": string;
+  "Triggered by": string;
+  "Successful Executions": number;
+  "Failed Executions": number;
+  Date: Date;
+}
+
 export interface ProcessedEvent {
   id: string;
   dateDisplay: string;


### PR DESCRIPTION
This pr addresses #52 and adds two majors things

1. There is now an `adminProtect` middleware that can be used on any functions that should only be accessible by administrators as denoted by the "Admin" checkbox in airtable
2. There is also now a popup showing all the messages sent in the last 7 days before allowing a user to send a recruitment text to prevent double texting. If there were no messages sent in the last 7 days it still brings up a confirmation popup.

<img width="1840" alt="image" src="https://github.com/grassrootsgrocery/admin-portal/assets/30198937/8a4cd5a4-5175-4918-b3fa-976565d442bf">
<img width="1840" alt="image" src="https://github.com/grassrootsgrocery/admin-portal/assets/30198937/9bc2ff44-086d-4cc9-a53c-83b7372f9ffb">
