### PR TITLE
Added new error handling for airtable fetches

### DIFF
--- a/server/middleware/authMiddleware.ts
+++ b/server/middleware/authMiddleware.ts
@@ -5,7 +5,7 @@ import { AIRTABLE_URL_BASE, airtableGET } from "../httpUtils/airtable";
 import { fetch } from "../httpUtils/nodeFetch";
 import { logger } from "../loggerUtils/logger";
 import { IncomingHttpHeaders } from "http";
-import { Record as AirtableRecord } from "../types";
+import { AirtableRecord } from "../types";
 
 // using any here because types are huge
 const checkTokenAndExtractUser = async (
@@ -48,6 +48,14 @@ const checkTokenAndExtractUser = async (
   const getUserResp = await airtableGET<{ Admin: boolean }>({
     url: getUserUrl,
   });
+
+  if (getUserResp.kind === "error") {
+    res.status(INTERNAL_SERVER_ERROR).json({
+      message: getUserResp.error,
+    });
+
+    throw new Error("Something went wrong finding the user");
+  }
 
   if (getUserResp.records.length === 0) {
     res.status(UNAUTHORIZED);

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -48,6 +48,14 @@ router.route("/api/auth/sign-up").post(
     const checkUserExistenceData = await airtableGET({
       url: checkUserExistenceUrl,
     });
+
+    if (checkUserExistenceData.kind === "error") {
+      res.status(INTERNAL_SERVER_ERROR).json({
+        message: checkUserExistenceData.error,
+      });
+      return;
+    }
+
     if (checkUserExistenceData.records.length > 0) {
       res.status(BAD_REQUEST);
       throw new Error("User already exists");
@@ -71,6 +79,14 @@ router.route("/api/auth/sign-up").post(
         ],
       },
     });
+
+    if (createUserData.kind === "error") {
+      res.status(INTERNAL_SERVER_ERROR).json({
+        message: createUserData.error,
+      });
+      return;
+    }
+
     const user = createUserData.records[0];
     if (!user.id) {
       //Should never happen
@@ -102,6 +118,14 @@ router.route("/api/auth/login").post(
     //Check if user exists
     const checkUserExistenceUrl = `${AIRTABLE_URL_BASE}/Users?filterByFormula=Username="${username}"`;
     const data = await airtableGET<User>({ url: checkUserExistenceUrl });
+
+    if (data.kind === "error") {
+      res.status(INTERNAL_SERVER_ERROR).json({
+        message: data.error,
+      });
+      return;
+    }
+
     if (data.records.length === 0) {
       logger.info("User doesn't exist");
       res.status(BAD_REQUEST);

--- a/server/routes/dropoffLocations.ts
+++ b/server/routes/dropoffLocations.ts
@@ -17,7 +17,7 @@ import {
 //Types
 import {
   AirtableResponse,
-  Record,
+  AirtableRecord,
   DropoffLocation,
   ProcessedDropoffLocation,
   Neighborhood,
@@ -30,7 +30,7 @@ import { logger } from "../loggerUtils/logger";
 const router = express.Router();
 
 function processDropOffLocations(
-  location: Record<DropoffLocation>
+  location: AirtableRecord<DropoffLocation>
 ): ProcessedDropoffLocation {
   const optionsTime = {
     hour: "numeric",
@@ -130,6 +130,15 @@ router.route("/api/dropoff-locations/").get(
     const dropoffLocations = await airtableGET<DropoffLocation>({
       url: dropoffLocationsUrl,
     });
+
+    if (dropoffLocations.kind == "error") {
+      res.status(INTERNAL_SERVER_ERROR).json({
+        message: dropoffLocations.error,
+      });
+
+      return;
+    }
+
     let processedDropOffLocations = dropoffLocations.records.map((location) =>
       processDropOffLocations(location)
     );
@@ -142,6 +151,15 @@ router.route("/api/dropoff-locations/").get(
     const neighborhoods = await airtableGET<Neighborhood>({
       url: neighborhoodsUrl,
     });
+
+    if (neighborhoods.kind == "error") {
+      res.status(INTERNAL_SERVER_ERROR).json({
+        message: neighborhoods.error,
+      });
+
+      return;
+    }
+
     let neighborhoodNamesById: Map<string, string> = new Map();
     neighborhoods.records.forEach((neighborhood) =>
       neighborhoodNamesById.set(neighborhood.id, neighborhood.fields.Name)

--- a/server/routes/messaging.ts
+++ b/server/routes/messaging.ts
@@ -229,6 +229,14 @@ router.route("/api/messaging/last-texts-sent").get(
 
     const data = await airtableGET<TextAutomation>({ url });
 
+    if (data.kind === "error") {
+      res.status(500).json({
+        message: data.error,
+      });
+
+      return;
+    }
+
     const fields = data.records.map((record) => record.fields);
 
     // only sends fields of each one

--- a/server/routes/neighborhoods.ts
+++ b/server/routes/neighborhoods.ts
@@ -39,6 +39,14 @@ router.route("/api/neighborhoods").get(
       `&fields%5B%5D=Name`;
 
     const neighborhoodsData = await airtableGET<Neighborhood>({ url: url });
+
+    if (neighborhoodsData.kind === "error") {
+      res.status(BAD_REQUEST).json({
+        message: neighborhoodsData.error,
+      });
+      return;
+    }
+
     const processedNeighborhoods: Neighborhood[] =
       neighborhoodsData.records.map((neighborhood) => {
         return {
@@ -46,7 +54,7 @@ router.route("/api/neighborhoods").get(
           Name: neighborhood.fields.Name,
         };
       });
-    res.status(OK).json(processedNeighborhoods) as Response<Neighborhood>;
+    res.status(OK).json(processedNeighborhoods);
   })
 );
 

--- a/server/routes/volunteers.ts
+++ b/server/routes/volunteers.ts
@@ -8,13 +8,17 @@ import {
 } from "../httpUtils/airtable";
 import { protect } from "../middleware/authMiddleware";
 //Status codes
-import { BAD_REQUEST, OK } from "../httpUtils/statusCodes";
+import {
+  BAD_REQUEST,
+  INTERNAL_SERVER_ERROR,
+  OK,
+} from "../httpUtils/statusCodes";
 //Types
 import {
   AirtableResponse,
   Driver,
   ProcessedDriver,
-  Record,
+  AirtableRecord,
   ScheduledSlot,
   ProcessedScheduledSlot,
 } from "../types";
@@ -25,7 +29,7 @@ import { logger } from "../loggerUtils/logger";
 const router = express.Router();
 
 function processScheduledSlots(
-  scheduledSlots: AirtableResponse<ScheduledSlot>
+  scheduledSlots: AirtableRecord<ScheduledSlot>[]
 ): ProcessedScheduledSlot[] {
   function getParticipantType(type: string[] | undefined) {
     if (!type) {
@@ -53,8 +57,10 @@ function processScheduledSlots(
     } as const;
     return new Date(timeslot).toLocaleString("en-US", optionsTime);
   }
+
   const volunteerList: ProcessedScheduledSlot[] = [];
-  for (const ss of scheduledSlots.records) {
+
+  for (const ss of scheduledSlots) {
     const participantType = getParticipantType(ss.fields["Type"]);
     const timeSlot =
       ss.fields["Correct slot time"] && !ss.fields["Correct slot time"]["error"]
@@ -86,6 +92,7 @@ function processScheduledSlots(
 
   return volunteerList;
 }
+
 /**
  * @description Get all volunteers who match the ids in the query param
  * @route  GET /api/volunteers/
@@ -122,7 +129,16 @@ router.route("/api/volunteers/").get(
       `&fields=Volunteer Group (for MAKE)`;
 
     const scheduledSlots = await airtableGET<ScheduledSlot>({ url: url });
-    const volunteers = processScheduledSlots(scheduledSlots);
+
+    if (scheduledSlots.kind === "error") {
+      res.status(INTERNAL_SERVER_ERROR).json({
+        message: scheduledSlots.error,
+      });
+
+      return;
+    }
+
+    const volunteers = processScheduledSlots(scheduledSlots.records);
 
     res.status(OK).json(volunteers);
   })
@@ -209,7 +225,7 @@ router.route("/api/volunteers/going/:volunteerId").patch(
   })
 );
 
-function processDriverData(driver: Record<Driver>): ProcessedDriver {
+function processDriverData(driver: AirtableRecord<Driver>): ProcessedDriver {
   // TODO: process restricted locations
   const optionsTime = {
     hour: "numeric",
@@ -273,7 +289,16 @@ router.route("/api/volunteers/drivers").get(
       `&fields=Restricted Neighborhoods` + // Restricted Locations
       `&fields=📍 Drop off location`; // Restricted Locations
 
-    const drivers = await airtableGET<Driver>({ url: url });
+    const drivers = await airtableGET<Driver>({ url });
+
+    if (drivers.kind === "error") {
+      res.status(BAD_REQUEST).json({
+        message: drivers.error,
+      });
+
+      return;
+    }
+
     let processedDrivers: ProcessedDriver[] = drivers.records.map((driver) =>
       processDriverData(driver)
     );

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,8 +1,12 @@
-export interface AirtableResponse<T> {
+/*export interface AirtableResponse<T> {
   records: Record<T>[];
-}
+}*/
 
-export interface Record<T> {
+export type AirtableResponse<T> =
+  | { kind: "success"; records: AirtableRecord<T>[]; error?: never }
+  | { kind: "error"; error: string; records?: never };
+
+export interface AirtableRecord<T> {
   id: string;
   fields: T;
   createdTime: string;


### PR DESCRIPTION
References #108

Use new AirtableResponse type to ensure errors relating to airtable fetches are communicated to the client. 

Also renames `Record` to `AirtableRecord` to avoid confusion with the builtin type `Record`

```ts
export type AirtableResponse<T> =
  | { kind: "success"; records: AirtableRecord<T>[]; error?: never }
  | { kind: "error"; error: string; records?: never };
```