### PR TITLE
Fix `mapper` error in messaging

### DIFF
--- a/server/routes/messaging.ts
+++ b/server/routes/messaging.ts
@@ -237,6 +237,11 @@ router.route("/api/messaging/last-texts-sent").get(
       return;
     }
 
+    if (data.records.length === 0) {
+      res.status(200).json([]);
+      return;
+    }
+
     const fields = data.records.map((record) => record.fields);
 
     // only sends fields of each one


### PR DESCRIPTION
## Description of this change
Attempting to fix as discussed on monday.com. Fix involves checking if array is empty before mapping.
```
[2023-08-12T12:54:51.756Z] ERROR: [200]: Cannot read properties of undefined (reading 'mapper') TypeError: Cannot read properties of undefined (reading 'mapper')
﻿at /app/dist/routes/messaging.js:230:83
﻿at step (/app/dist/routes/messaging.js:33:23)
﻿at Object.next (/app/dist/routes/messaging.js:14:53)
﻿at fulfilled (/app/dist/routes/messaging.js:5:58)
﻿at runMicrotasks (<anonymous>)
﻿at processTicksAndRejections (node:internal/process/task_queues:96:5)
```