### PR TITLE
Fixed the location of where to fetch the text message body from the b…

### DIFF
--- a/server/routes/messaging.ts
+++ b/server/routes/messaging.ts
@@ -189,7 +189,7 @@ router.route("/api/messaging/locations-to-drivers-text").get(
       res,
       "There was a problem fetching the '[NEW] Send Locations and POC details to volunteer drivers (only text, no email)' text."
     );
-    res.status(OK).json(data.response.blueprint.flow[5].mapper.body);
+    res.status(OK).json(data.response.blueprint.flow[3].routes[0].flow[6].mapper.body);
   })
 );
 


### PR DESCRIPTION
## Description of this change
Fixed the location of the text message body in the response of /api/messaging/locations-to-drivers-text/ response. It had moved due to the Make scenario changing recently and this part of code needs to be updated. This is a temporary fix as we need something long term that is not fragile.

## Screenshots (for UI changes - otherwise delete this section)
### Before this PR:
![image](https://github.com/grassrootsgrocery/admin-portal/assets/15386131/a21125d0-c974-408a-be30-06160481734a)

### After this PR:
![image](https://github.com/grassrootsgrocery/admin-portal/assets/15386131/8e205177-4444-4852-956b-6c7de1fd111d)


