### PR TITLE
138 update special event link

### DIFF
--- a/client/src/pages/ViewEvent/AddSpecialGroup/AddSpecialGroup.tsx
+++ b/client/src/pages/ViewEvent/AddSpecialGroup/AddSpecialGroup.tsx
@@ -76,7 +76,6 @@ export const AddSpecialGroup: React.FC<Props> = ({
         data
       );
 
-      const typedData = data as AirtableResponse<any>;
       //TODO: We should maybe type the response?
       setNewlyAddedGroupSignUpLink(
         data.records[0].fields["Fillout Special Event Signup"] ||

--- a/client/src/pages/ViewEvent/AddSpecialGroup/AddSpecialGroup.tsx
+++ b/client/src/pages/ViewEvent/AddSpecialGroup/AddSpecialGroup.tsx
@@ -8,6 +8,7 @@ import { ProcessedEvent, ProcessedSpecialGroup } from "../../../types";
 import check from "../../../assets/check.svg";
 import plus from "../../../assets/plus.svg";
 import { useSpecialGroups } from "../specialGroupsHooks";
+import { AirtableResponse } from "../../../../../server/types";
 
 interface Props {
   event: ProcessedEvent;
@@ -75,10 +76,11 @@ export const AddSpecialGroup: React.FC<Props> = ({
         "Data returned from POST /api/special-groups/add-special-group-to-event",
         data
       );
+
+      const typedData = data as AirtableResponse<any>;
       //TODO: We should maybe type the response?
       setNewlyAddedGroupSignUpLink(
-        data.records[0].fields["Shortened Link to Special Event Signup Form"] ||
-          data.records[0].fields["Link to Special Event Signup Form"] ||
+        data.records[0].fields["Fillout Special Event Signup"] ||
           "Uh oh, where is the link?"
       );
       specialGroupsQuery.refetch();

--- a/client/src/pages/ViewEvent/AddSpecialGroup/AddSpecialGroup.tsx
+++ b/client/src/pages/ViewEvent/AddSpecialGroup/AddSpecialGroup.tsx
@@ -8,7 +8,6 @@ import { ProcessedEvent, ProcessedSpecialGroup } from "../../../types";
 import check from "../../../assets/check.svg";
 import plus from "../../../assets/plus.svg";
 import { useSpecialGroups } from "../specialGroupsHooks";
-import { AirtableResponse } from "../../../../../server/types";
 
 interface Props {
   event: ProcessedEvent;

--- a/client/src/pages/ViewEvent/ViewSpecialGroups.tsx
+++ b/client/src/pages/ViewEvent/ViewSpecialGroups.tsx
@@ -43,7 +43,17 @@ function processSpecialGroups(
       1 "St. Augustine's"
       2 "https://bit.ly/3HohS3x"
     */
-    return [se.id, groupName, <a href={se.eventSignUpLink} target="_blank" className="text-blue-500 underline">se.eventSignUpLink</a>];
+    return [
+      se.id,
+      groupName,
+      <a
+        href={se.eventSignUpLink}
+        target="_blank"
+        className="text-blue-500 underline"
+      >
+        Link
+      </a>,
+    ];
   });
 }
 
@@ -89,17 +99,17 @@ export const ViewSpecialGroups: React.FC<Props> = ({ event }: Props) => {
   return (
     <Popup
       className={cn(
-        "bg-softBeige fixed left-[50%] top-[50%] w-full w-full -translate-x-1/2 -translate-y-1/2 rounded-lg px-3 py-4",
+        "fixed left-[50%] top-[50%] w-full w-full -translate-x-1/2 -translate-y-1/2 rounded-lg bg-softBeige px-3 py-4",
         "md:w-[40rem] md:py-6 md:px-8"
       )}
       onOpenChange={() => refetchSpecialEvents()}
       trigger={
         <button
           className={
-            "bg-pumpkinOrange lg:shadow-newLeafGreen rounded-full px-3 py-2 text-sm font-semibold text-white outline-none lg:px-5 lg:py-3 lg:text-base lg:font-bold lg:shadow-md lg:transition-all " +
+            "rounded-full bg-pumpkinOrange px-3 py-2 text-sm font-semibold text-white outline-none lg:px-5 lg:py-3 lg:text-base lg:font-bold lg:shadow-md lg:shadow-newLeafGreen lg:transition-all " +
             (disabled
               ? "opacity-50"
-              : "lg:hover:shadow-newLeafGreen lg:hover:-translate-y-1 lg:hover:shadow-lg")
+              : "lg:hover:-translate-y-1 lg:hover:shadow-lg lg:hover:shadow-newLeafGreen")
           }
           disabled={disabled}
           type="button"
@@ -109,7 +119,7 @@ export const ViewSpecialGroups: React.FC<Props> = ({ event }: Props) => {
       }
     >
       <>
-        <Modal.Title className="text-newLeafGreen m-0 flex justify-center text-xl font-bold lg:px-16 lg:text-3xl">
+        <Modal.Title className="m-0 flex justify-center text-xl font-bold text-newLeafGreen lg:px-16 lg:text-3xl">
           View Event Special Groups
         </Modal.Title>
         <div className="h-3 md:h-6" />
@@ -126,7 +136,7 @@ export const ViewSpecialGroups: React.FC<Props> = ({ event }: Props) => {
         <div className="flex justify-center">
           <Modal.Close
             className={cn(
-              "bg-newLeafGreen rounded-full px-3 py-2 text-xs font-semibold text-white hover:brightness-150 focus:brightness-150",
+              "rounded-full bg-newLeafGreen px-3 py-2 text-xs font-semibold text-white hover:brightness-150 focus:brightness-150",
               "lg:px-5 lg:py-3 lg:text-base lg:font-bold"
             )}
           >

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -272,7 +272,7 @@ router.route("/api/events/view-event-special-groups/").get(
             ? specialEvent.fields["Volunteer Group"][0]
             : "NO ID",
           eventSignUpLink:
-            specialEvent.fields["Jotform Special Event Sign-Up"] ||
+            specialEvent.fields["Fillout Special Event Signup"] ||
             "No sign up link",
         };
       });

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -252,7 +252,7 @@ router.route("/api/events/view-event-special-groups/").get(
       `filterByFormula=AND(SEARCH(RECORD_ID(), "${eventIds}") != "",` +
       `{Special Event})` + //  get events that are special events
       `&fields=Volunteer Group` + // Special Group
-      `&fields=Jotform Special Event Sign-Up`; // Special Event Link
+      `&fields=Fillout Special Event Signup`; // Special Event Link
 
     const specialEvents = await airtableGET<SpecialEvent>({ url: url });
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -178,7 +178,7 @@ export interface ProcessedSpecialGroup {
 
 export interface SpecialEvent {
   "Volunteer Group": string | undefined;
-  "Jotform Special Event Sign-Up": string | undefined;
+  "Fillout Special Event Signup": string | undefined;
 }
 
 export interface ProcessedSpecialEvent {


### PR DESCRIPTION
## Description of this change
Pulls the form link from `Fillout Special Event Signup`
Closes #138 
## Screenshots (for UI changes - otherwise delete this section)
### Before this PR:

![](https://user-images.githubusercontent.com/74022561/266800673-ab1c0d2b-21b6-4dca-b101-366c070ee32c.png)

### After this PR:

<img width="1840" alt="image" src="https://github.com/grassrootsgrocery/admin-portal/assets/30198937/0ed885ae-28a5-41cf-8676-03fbbbc6533e">

## Checklist
- [x] Added link to existing Issue (created issue if there wasn't one already)
- [x] Added screenshots before/after for UI changes
- [x] PR is from branch pushed to this repo so that it will trigger Railway PR deployment
- [x] Code follows the style of this project
