### PR TITLE
141 warning if volunteer info is missing

### DIFF
--- a/client/src/pages/Events/EventCard.tsx
+++ b/client/src/pages/Events/EventCard.tsx
@@ -11,6 +11,7 @@ interface Props {
   participants: number;
   drivers: number;
   packers: number;
+  warnings: number;
 }
 
 export const EventCard: React.FC<Props> = ({
@@ -21,6 +22,7 @@ export const EventCard: React.FC<Props> = ({
   eventId,
   drivers,
   packers,
+  warnings,
 }) => {
   // Tailwind classes
   const label = "text-sm md:text-base lg:text-xl";
@@ -79,6 +81,16 @@ export const EventCard: React.FC<Props> = ({
               Total Participants
             </p>
             <h3 className={labelBold}>{participants}</h3>
+          </div>
+          {/* Warnings Count */}
+          <div className="ml-12 flex flex-grow flex-wrap items-center justify-center">
+            {warnings > 0 && (
+              <div className="flex items-center p-2">
+                <p className="font-bold text-red-600 lg:text-xl">
+                  ⚠️ {warnings} volunteer(s) missing info
+                </p>
+              </div>
+            )}
           </div>
           <div className="flex grow items-center lg:justify-end">
             <Link to={`/events/${eventId}`}>

--- a/client/src/pages/Events/EventCard.tsx
+++ b/client/src/pages/Events/EventCard.tsx
@@ -11,7 +11,6 @@ interface Props {
   participants: number;
   drivers: number;
   packers: number;
-  warnings: number;
 }
 
 export const EventCard: React.FC<Props> = ({
@@ -22,7 +21,6 @@ export const EventCard: React.FC<Props> = ({
   eventId,
   drivers,
   packers,
-  warnings,
 }) => {
   // Tailwind classes
   const label = "text-sm md:text-base lg:text-xl";
@@ -81,16 +79,6 @@ export const EventCard: React.FC<Props> = ({
               Total Participants
             </p>
             <h3 className={labelBold}>{participants}</h3>
-          </div>
-          {/* Warnings Count */}
-          <div className="ml-12 flex flex-grow flex-wrap items-center justify-center">
-            {warnings > 0 && (
-              <div className="flex items-center p-2">
-                <p className="font-bold text-red-600 lg:text-xl">
-                  ⚠️ {warnings} volunteer(s) missing info
-                </p>
-              </div>
-            )}
           </div>
           <div className="flex grow items-center lg:justify-end">
             <Link to={`/events/${eventId}`}>

--- a/client/src/pages/Events/Events.tsx
+++ b/client/src/pages/Events/Events.tsx
@@ -2,11 +2,12 @@ import { EventCard } from "./EventCard";
 import { Loading } from "../../components/Loading";
 import { Navbar } from "../../components/Navbar";
 import { useAuth } from "../../contexts/AuthContext";
-import { Navigate } from "react-router-dom";
+import { Link, Navigate,useParams } from "react-router-dom";
 import { useFutureEvents } from "../eventHooks";
 import { toastNotify } from "../../utils/ui";
-import { WarningsCounter } from "../../pages/ViewEvent/VolunteersTable";
 
+import { useFutureEventById, useVolunteersForEvent } from "../eventHooks";
+import { WarningsUpdater } from "../../pages/ViewEvent/VolunteersTable";
 
 const newEventLink =
   "https://airtable.com/shrETAYONKTJMVTnZ?prefill_Supplier=Rap+4+Bronx&prefill_Start+Time=01/01/2023+09:00am&prefill_End+Time=01/01/2023+01:00pm&prefill_First+Driving+Slot+Start+Time=01/01/2023+10:30am&prefill_How+long+should+each+Driver+Time+Slot+be?=0:15&prefill_Max+Count+of+Drivers+Per+Slot=30&prefill_How+long+should+the+Logistics+slot+be?=1:30&prefill_Maximum+number+of+drivers+needed+for+this+event+(usually+30)?=30&prefill_Max+Count+of+Distributors+Per+Slot=30";
@@ -58,10 +59,10 @@ export function Events() {
             </button>
           </a>
         </div>
-        <div className="h-5" />
         <ul className="flex h-0 grow flex-col gap-2 overflow-auto pr-2 sm:gap-7 md:pr-4">
           {futureEventsQuery.data.map((event) => {
             return (
+              
               <EventCard
                 key={event.id}
                 eventId={event.id}
@@ -71,15 +72,12 @@ export function Events() {
                 participants={event.numTotalParticipants}
                 drivers={event.numDrivers}
                 packers={event.numPackers}
+                warnings={0}
               />
-              
             );
           })}
-          
         </ul>
-        
       </div>
-      
     </>
   );
 }

--- a/client/src/pages/Events/Events.tsx
+++ b/client/src/pages/Events/Events.tsx
@@ -2,13 +2,9 @@ import { EventCard } from "./EventCard";
 import { Loading } from "../../components/Loading";
 import { Navbar } from "../../components/Navbar";
 import { useAuth } from "../../contexts/AuthContext";
-import { Link, Navigate,useParams } from "react-router-dom";
+import { Navigate} from "react-router-dom";
 import { useFutureEvents } from "../eventHooks";
 import { toastNotify } from "../../utils/ui";
-
-import { useFutureEventById, useVolunteersForEvent } from "../eventHooks";
-import { WarningsUpdater } from "../../pages/ViewEvent/VolunteersTable";
-
 const newEventLink =
   "https://airtable.com/shrETAYONKTJMVTnZ?prefill_Supplier=Rap+4+Bronx&prefill_Start+Time=01/01/2023+09:00am&prefill_End+Time=01/01/2023+01:00pm&prefill_First+Driving+Slot+Start+Time=01/01/2023+10:30am&prefill_How+long+should+each+Driver+Time+Slot+be?=0:15&prefill_Max+Count+of+Drivers+Per+Slot=30&prefill_How+long+should+the+Logistics+slot+be?=1:30&prefill_Maximum+number+of+drivers+needed+for+this+event+(usually+30)?=30&prefill_Max+Count+of+Distributors+Per+Slot=30";
 
@@ -62,7 +58,6 @@ export function Events() {
         <ul className="flex h-0 grow flex-col gap-2 overflow-auto pr-2 sm:gap-7 md:pr-4">
           {futureEventsQuery.data.map((event) => {
             return (
-              
               <EventCard
                 key={event.id}
                 eventId={event.id}
@@ -72,7 +67,6 @@ export function Events() {
                 participants={event.numTotalParticipants}
                 drivers={event.numDrivers}
                 packers={event.numPackers}
-                warnings={0}
               />
             );
           })}

--- a/client/src/pages/Events/Events.tsx
+++ b/client/src/pages/Events/Events.tsx
@@ -5,6 +5,8 @@ import { useAuth } from "../../contexts/AuthContext";
 import { Navigate } from "react-router-dom";
 import { useFutureEvents } from "../eventHooks";
 import { toastNotify } from "../../utils/ui";
+import { WarningsCounter } from "../../pages/ViewEvent/VolunteersTable";
+
 
 const newEventLink =
   "https://airtable.com/shrETAYONKTJMVTnZ?prefill_Supplier=Rap+4+Bronx&prefill_Start+Time=01/01/2023+09:00am&prefill_End+Time=01/01/2023+01:00pm&prefill_First+Driving+Slot+Start+Time=01/01/2023+10:30am&prefill_How+long+should+each+Driver+Time+Slot+be?=0:15&prefill_Max+Count+of+Drivers+Per+Slot=30&prefill_How+long+should+the+Logistics+slot+be?=1:30&prefill_Maximum+number+of+drivers+needed+for+this+event+(usually+30)?=30&prefill_Max+Count+of+Distributors+Per+Slot=30";
@@ -70,10 +72,14 @@ export function Events() {
                 drivers={event.numDrivers}
                 packers={event.numPackers}
               />
+              
             );
           })}
+          
         </ul>
+        
       </div>
+      
     </>
   );
 }

--- a/client/src/pages/Events/Events.tsx
+++ b/client/src/pages/Events/Events.tsx
@@ -2,7 +2,7 @@ import { EventCard } from "./EventCard";
 import { Loading } from "../../components/Loading";
 import { Navbar } from "../../components/Navbar";
 import { useAuth } from "../../contexts/AuthContext";
-import { Navigate} from "react-router-dom";
+import { Navigate } from "react-router-dom";
 import { useFutureEvents } from "../eventHooks";
 import { toastNotify } from "../../utils/ui";
 const newEventLink =
@@ -55,6 +55,7 @@ export function Events() {
             </button>
           </a>
         </div>
+        <div className="h-5" />
         <ul className="flex h-0 grow flex-col gap-2 overflow-auto pr-2 sm:gap-7 md:pr-4">
           {futureEventsQuery.data.map((event) => {
             return (

--- a/client/src/pages/ViewEvent/ViewEvent.tsx
+++ b/client/src/pages/ViewEvent/ViewEvent.tsx
@@ -19,7 +19,7 @@ import { AddSpecialGroup } from "./AddSpecialGroup";
 import { useAuth } from "../../contexts/AuthContext";
 import { ViewSpecialGroups } from "./ViewSpecialGroups";
 import { toastNotify } from "../../utils/ui";
-import { WarningsCounter } from "./VolunteersTable";
+import { WarningsUpdater } from "./VolunteersTable";
 
 const HeaderValueDisplay: React.FC<{
   header: string;
@@ -102,12 +102,16 @@ export const ViewEvent = () => {
             <img className={sectionHeaderIcon} src={calendar} alt="calendar" />
             {event.dateDisplay}
           </h1>
+          {/* Warnings Count */}
           <div className="ml-12 flex flex-grow flex-wrap items-center justify-center">
-            <div className="flex items-center border-2 border-red-600 p-2">
-              <p className="font-bold text-red-600 lg:text-xl">
-                Warnings: {WarningsCounter.count} volunteer(s) missing info
-              </p>
-            </div>
+            {WarningsUpdater(scheduledSlots, eventId) > 0 && (
+              <div className="flex items-center border-2 border-red-600 p-2">
+                <p className="font-bold text-red-600 lg:text-xl">
+                  ⚠️ {WarningsUpdater(scheduledSlots, eventId)} volunteer(s)
+                  missing info
+                </p>
+              </div>
+            )}
           </div>
         </div>
         <div className="h-4" />
@@ -163,7 +167,6 @@ export const ViewEvent = () => {
               header="# of Special Groups"
               value={event.numSpecialGroups}
             />
-    
           </div>
 
           <div className="flex flex-col items-start justify-around gap-2 ">

--- a/client/src/pages/ViewEvent/ViewEvent.tsx
+++ b/client/src/pages/ViewEvent/ViewEvent.tsx
@@ -19,6 +19,7 @@ import { AddSpecialGroup } from "./AddSpecialGroup";
 import { useAuth } from "../../contexts/AuthContext";
 import { ViewSpecialGroups } from "./ViewSpecialGroups";
 import { toastNotify } from "../../utils/ui";
+import { WarningsCounter } from "./VolunteersTable";
 
 const HeaderValueDisplay: React.FC<{
   header: string;
@@ -81,6 +82,7 @@ export const ViewEvent = () => {
     return <div>Error...</div>;
   }
 
+  
   const event = eventQuery.data;
   const scheduledSlots = scheduledSlotsQuery.data;
   scheduledSlots.sort((a, b) => (a.firstName < b.firstName ? -1 : 1));
@@ -95,10 +97,19 @@ export const ViewEvent = () => {
       <Navbar />
       <div className="p-6 lg:px-14 lg:py-10">
         {/* Event Info */}
-        <h1 className={sectionHeader}>
-          <img className={sectionHeaderIcon} src={calendar} alt="calendar" />
-          {event.dateDisplay}
-        </h1>
+        <div className="flex justify-between">
+          <h1 className={sectionHeader}>
+            <img className={sectionHeaderIcon} src={calendar} alt="calendar" />
+            {event.dateDisplay}
+          </h1>
+          <div className="ml-12 flex flex-grow flex-wrap items-center justify-center">
+            <div className="flex items-center border-2 border-red-600 p-2">
+              <p className="font-bold text-red-600 lg:text-xl">
+                Warnings: {WarningsCounter.count} volunteer(s) missing info
+              </p>
+            </div>
+          </div>
+        </div>
         <div className="h-4" />
         <div className="flex flex-col gap-3 md:flex-row md:gap-10">
           <HeaderValueDisplay header="Time" value={event.time} />
@@ -111,6 +122,7 @@ export const ViewEvent = () => {
             value={event.numTotalParticipants}
           />
         </div>
+
         <div className="h-12" />
         {/* Participant Breakdown */}
         <h1 className={sectionHeader}>
@@ -151,6 +163,7 @@ export const ViewEvent = () => {
               header="# of Special Groups"
               value={event.numSpecialGroups}
             />
+    
           </div>
 
           <div className="flex flex-col items-start justify-around gap-2 ">

--- a/client/src/pages/ViewEvent/VolunteersTable.tsx
+++ b/client/src/pages/ViewEvent/VolunteersTable.tsx
@@ -287,91 +287,91 @@ export const VolunteersTable: React.FC<{
     setFilters(newSelectedFilters);
     setFiltered(applySelectedFilters(newSelectedFilters, scheduledSlots));
   };
-
   //Takes in scheduledSlots array and formats data for DataTable component
   function processScheduledSlotsForTable(
     scheduledSlots: ProcessedScheduledSlot[],
     eventId: string
   ): (string | number | JSX.Element)[][] {
-    const { token } = useAuth();
-    const queryClient = useQueryClient();
-    const rows = scheduledSlots.map((ss, i) => {
-      let firstName = ss.firstName;
-      if (
-        typeof ss.firstName === "undefined" ||
-        typeof ss.lastName === "undefined" ||
-        typeof ss.timeSlot === "undefined" ||
-        typeof ss.participantType === "undefined" ||
-        typeof ss.phoneNumber === "undefined" ||
-        typeof ss.email === "undefined"
-      ) {
-        firstName = `⚠️ ${firstName}`;
-      }
-      return [
-        ss.id,
-        i + 1,
-        firstName,
-        ss.lastName,
-        ss.timeSlot,
-        ss.participantType,
-        /* Confirmed Checkbox */
-        <HttpCheckbox
-          checked={ss.confirmed}
-          mutationFn={applyPatch(
-            `/api/volunteers/confirm/${ss.id}`,
-            { newConfirmationStatus: !ss.confirmed },
-            token as string
-          )}
-          onSuccess={() => {
-            const toastMessage = `${ss.firstName} ${ss.lastName} ${
-              ss.confirmed ? "unconfirmed" : "confirmed"
-            }`;
-            queryClient.invalidateQueries(
-              VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
-            );
-            toastNotify(toastMessage, "success");
-          }}
-          onError={() => toastNotify("Unable to confirm volunteer", "failure")}
-        />,
-        /* Not Going Checkbox */
-        <HttpCheckbox
-          checked={ss.cantCome}
-          mutationFn={applyPatch(
-            `/api/volunteers/going/${ss.id}`,
-            { newGoingStatus: !ss.cantCome },
-            token as string
-          )}
-          onSuccess={() => {
-            const toastMessage = `${ss.firstName} ${ss.lastName} ${
-              ss.cantCome ? "is able to volunteer" : "is unable to volunteer"
-            }`;
-            queryClient.invalidateQueries(
-              VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
-            );
-            toastNotify(toastMessage, "success");
-          }}
-          onError={() => toastNotify("Unable to modify availability", "failure")}
-        />,
-        ss.specialGroup ?? "N/A",
-        typeof ss.totalDeliveries === "number" ? ss.totalDeliveries : "N/A",
-        /* Contact Modal */
-        <ContactPopup phoneNumber={ss.phoneNumber} email={ss.email} />,
-        <EditVolunteerPopup
-          id={ss.id}
-          email={ss.email}
-          phoneNumber={ss.phoneNumber}
-          firstName={ss.firstName}
-          lastName={ss.lastName}
-          participantType={ss.participantType}
-          onEditSuccess={() => {
-            queryClient.invalidateQueries(
-              VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
-            );
-          }}
-        />,
-      ];
-    });
+  const { token } = useAuth();
+  const queryClient = useQueryClient();
+  const rows = scheduledSlots.map((ss, i) => {
+    let firstName = ss.firstName;
+    if (
+      typeof ss.firstName === "undefined" ||
+      typeof ss.lastName === "undefined" ||
+      typeof ss.timeSlot === "undefined" ||
+      typeof ss.participantType === "undefined" ||
+      typeof ss.phoneNumber === "undefined" ||
+      typeof ss.email === "undefined"
+    ) {
+      firstName = `⚠️ ${firstName}`;
+    }
+    return [
+      ss.id,
+      i + 1,
+      firstName,
+      ss.lastName,
+      ss.timeSlot,
+      ss.participantType,
+      /* Confirmed Checkbox */
+      <HttpCheckbox
+        checked={ss.confirmed}
+        mutationFn={applyPatch(
+          `/api/volunteers/confirm/${ss.id}`,
+          { newConfirmationStatus: !ss.confirmed },
+          token as string
+        )}
+        onSuccess={() => {
+          const toastMessage = `${ss.firstName} ${ss.lastName} ${
+            ss.confirmed ? "unconfirmed" : "confirmed"
+          }`;
+          queryClient.invalidateQueries(
+            VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
+          );
+          toastNotify(toastMessage, "success");
+        }}
+        onError={() => toastNotify("Unable to confirm volunteer", "failure")}
+      />,
+      /* Not Going Checkbox */
+      <HttpCheckbox
+        checked={ss.cantCome}
+        mutationFn={applyPatch(
+          `/api/volunteers/going/${ss.id}`,
+          { newGoingStatus: !ss.cantCome },
+          token as string
+        )}
+        onSuccess={() => {
+          const toastMessage = `${ss.firstName} ${ss.lastName} ${
+            ss.cantCome ? "is able to volunteer" : "is unable to volunteer"
+          }`;
+          queryClient.invalidateQueries(
+            VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
+          );
+          toastNotify(toastMessage, "success");
+        }}
+        onError={() => toastNotify("Unable to modify availability", "failure")}
+      />,
+      ss.specialGroup ?? "N/A",
+      typeof ss.totalDeliveries === "number" ? ss.totalDeliveries : "N/A",
+      /* Contact Modal */
+      <ContactPopup phoneNumber={ss.phoneNumber} email={ss.email} />,
+      <EditVolunteerPopup
+        id={ss.id}
+        email={ss.email}
+        phoneNumber={ss.phoneNumber}
+        firstName={ss.firstName}
+        lastName={ss.lastName}
+        participantType={ss.participantType}
+        onEditSuccess={() => {
+          queryClient.invalidateQueries(
+            VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
+          );
+        }}
+      />,
+    ];
+  });
     return rows;
+
   }
 
   filtered.sort((a, b) => {
@@ -383,7 +383,6 @@ export const VolunteersTable: React.FC<{
     }
     return a.firstName < b.firstName ? -1 : 1;
   });
-
   // UI
   return (
     <div className="flex h-screen flex-col pt-6">
@@ -474,7 +473,6 @@ export const VolunteersTable: React.FC<{
           "Participant Type",
           "Confirmed",
           "Can't Come",
-          "Past Events",
           "Special Group",
           "Delivery Count",
           "Contact",

--- a/client/src/pages/ViewEvent/VolunteersTable.tsx
+++ b/client/src/pages/ViewEvent/VolunteersTable.tsx
@@ -24,6 +24,7 @@ import { VOLUNTEERS_FOR_EVENT_QUERY_KEYS } from "../eventHooks";
 TODO: There is a lot of stuff going on in this component, and we should perhaps look into refactoring at some point. 
 */
 
+
 interface FilterItemProps {
   onSelect: () => void;
   filterLabel: string;
@@ -166,6 +167,8 @@ const applySelectedFilters = (
   return filteredItems;
 };
 
+export const WarningsCounter = { count: 0 };
+
 export const VolunteersTable: React.FC<{
   scheduledSlots: ProcessedScheduledSlot[];
   eventId: string;
@@ -193,23 +196,45 @@ export const VolunteersTable: React.FC<{
     setFiltered(applySelectedFilters(newSelectedFilters, scheduledSlots));
   };
 
+  
   //Takes in scheduledSlots array and formats data for DataTable component
   function processScheduledSlotsForTable(
     scheduledSlots: ProcessedScheduledSlot[],
     eventId: string
   ): (string | number | JSX.Element)[][] {
+  
     const { token } = useAuth();
+    const getWarningSymbol = (fieldName: string) => {
+        WarningsCounter.count=WarningsCounter.count+1;
+        return `⚠️ ${fieldName}`;
+    };
+    WarningsCounter.count = 0;
+    
     const queryClient = useQueryClient();
     const rows = scheduledSlots.map((ss, i) => {
-      return [
-        /* id */
-        ss.id,
-        /* # */
-        i + 1,
-        ss.firstName,
-        ss.lastName,
-        ss.timeSlot,
-        ss.participantType,
+      let firstName=ss.firstName;
+      //Warning sign next to name works, need to fix warnings count and create red component for warning count and add to main event page as well.
+      if (typeof ss.firstName === "undefined") {
+      firstName = getWarningSymbol(firstName);
+    } else if (typeof ss.lastName === "undefined") {
+       firstName = getWarningSymbol(firstName);
+    } else if (typeof ss.timeSlot === "undefined") {
+       firstName = getWarningSymbol(firstName);
+    } else if (ss.participantType === "Driver") {
+       firstName = getWarningSymbol(firstName);
+    } else if (typeof ss.phoneNumber === "undefined") {
+       firstName = getWarningSymbol(firstName);
+    } else if (typeof ss.email === "undefined") {
+       firstName = getWarningSymbol(firstName);
+    }
+
+    return [
+      ss.id,
+      i + 1,
+      firstName,
+      ss.lastName,
+      ss.timeSlot,
+      ss.participantType,
         /* Confirmed Checkbox */
         <HttpCheckbox
           checked={ss.confirmed}
@@ -269,8 +294,8 @@ export const VolunteersTable: React.FC<{
         />,
       ];
     });
-
     return rows;
+
   }
 
   filtered.sort((a, b) => {
@@ -382,3 +407,4 @@ export const VolunteersTable: React.FC<{
     </div>
   );
 };
+

--- a/client/src/pages/ViewEvent/VolunteersTable.tsx
+++ b/client/src/pages/ViewEvent/VolunteersTable.tsx
@@ -24,7 +24,6 @@ import { VOLUNTEERS_FOR_EVENT_QUERY_KEYS } from "../eventHooks";
 TODO: There is a lot of stuff going on in this component, and we should perhaps look into refactoring at some point. 
 */
 
-
 interface FilterItemProps {
   onSelect: () => void;
   filterLabel: string;
@@ -188,7 +187,7 @@ export function WarningsUpdater(
       typeof ss.firstName === "undefined" ||
       typeof ss.lastName === "undefined" ||
       typeof ss.timeSlot === "undefined" ||
-      ss.participantType === "Driver" ||
+      typeof ss.participantType === "undefined" ||
       typeof ss.phoneNumber === "undefined" ||
       typeof ss.email === "undefined"
     ) {
@@ -294,23 +293,18 @@ export const VolunteersTable: React.FC<{
     eventId: string
   ): (string | number | JSX.Element)[][] {
   const { token } = useAuth();
-  const getWarningSymbol = (fieldName: string) => {
-    return `⚠️ ${fieldName}`;
-  };
   const queryClient = useQueryClient();
   const rows = scheduledSlots.map((ss, i) => {
     let firstName = ss.firstName;
-    //Warning sign next to name works, need to fix warnings count and create red component for warning count and add to main event page as well.
-
     if (
       typeof ss.firstName === "undefined" ||
       typeof ss.lastName === "undefined" ||
       typeof ss.timeSlot === "undefined" ||
-      ss.participantType === "Driver" ||
+      typeof ss.participantType === "undefined" ||
       typeof ss.phoneNumber === "undefined" ||
       typeof ss.email === "undefined"
     ) {
-      firstName = getWarningSymbol(firstName);
+      firstName = `⚠️ ${firstName}`;
     }
     return [
       ss.id,

--- a/client/src/pages/ViewEvent/VolunteersTable.tsx
+++ b/client/src/pages/ViewEvent/VolunteersTable.tsx
@@ -167,7 +167,100 @@ const applySelectedFilters = (
   return filteredItems;
 };
 
-export const WarningsCounter = { count: 0 };
+export function WarningsUpdater(
+  scheduledSlots: ProcessedScheduledSlot[],
+  eventId: string
+): number {
+  const WarningsCounter = { count: 0 };
+  const { token } = useAuth();
+  const getWarningSymbol = (fieldName: string) => {
+    WarningsCounter.count = WarningsCounter.count + 1;
+    return `⚠️ ${fieldName}`;
+  };
+  WarningsCounter.count = 0;
+
+  const queryClient = useQueryClient();
+  const rows = scheduledSlots.map((ss, i) => {
+    let firstName = ss.firstName;
+    //Warning sign next to name works, need to fix warnings count and create red component for warning count and add to main event page as well.
+
+    if (
+      typeof ss.firstName === "undefined" ||
+      typeof ss.lastName === "undefined" ||
+      typeof ss.timeSlot === "undefined" ||
+      ss.participantType === "Driver" ||
+      typeof ss.phoneNumber === "undefined" ||
+      typeof ss.email === "undefined"
+    ) {
+      firstName = getWarningSymbol(firstName);
+    }
+
+    return [
+      ss.id,
+      i + 1,
+      firstName,
+      ss.lastName,
+      ss.timeSlot,
+      ss.participantType,
+      /* Confirmed Checkbox */
+      <HttpCheckbox
+        checked={ss.confirmed}
+        mutationFn={applyPatch(
+          `/api/volunteers/confirm/${ss.id}`,
+          { newConfirmationStatus: !ss.confirmed },
+          token as string
+        )}
+        onSuccess={() => {
+          const toastMessage = `${ss.firstName} ${ss.lastName} ${
+            ss.confirmed ? "unconfirmed" : "confirmed"
+          }`;
+          queryClient.invalidateQueries(
+            VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
+          );
+          toastNotify(toastMessage, "success");
+        }}
+        onError={() => toastNotify("Unable to confirm volunteer", "failure")}
+      />,
+      /* Not Going Checkbox */
+      <HttpCheckbox
+        checked={ss.cantCome}
+        mutationFn={applyPatch(
+          `/api/volunteers/going/${ss.id}`,
+          { newGoingStatus: !ss.cantCome },
+          token as string
+        )}
+        onSuccess={() => {
+          const toastMessage = `${ss.firstName} ${ss.lastName} ${
+            ss.cantCome ? "is able to volunteer" : "is unable to volunteer"
+          }`;
+          queryClient.invalidateQueries(
+            VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
+          );
+          toastNotify(toastMessage, "success");
+        }}
+        onError={() => toastNotify("Unable to modify availability", "failure")}
+      />,
+      ss.specialGroup ?? "N/A",
+      typeof ss.totalDeliveries === "number" ? ss.totalDeliveries : "N/A",
+      /* Contact Modal */
+      <ContactPopup phoneNumber={ss.phoneNumber} email={ss.email} />,
+      <EditVolunteerPopup
+        id={ss.id}
+        email={ss.email}
+        phoneNumber={ss.phoneNumber}
+        firstName={ss.firstName}
+        lastName={ss.lastName}
+        participantType={ss.participantType}
+        onEditSuccess={() => {
+          queryClient.invalidateQueries(
+            VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
+          );
+        }}
+      />,
+    ];
+  });
+  return WarningsCounter.count;
+}
 
 export const VolunteersTable: React.FC<{
   scheduledSlots: ProcessedScheduledSlot[];
@@ -195,39 +288,30 @@ export const VolunteersTable: React.FC<{
     setFilters(newSelectedFilters);
     setFiltered(applySelectedFilters(newSelectedFilters, scheduledSlots));
   };
-
-  
   //Takes in scheduledSlots array and formats data for DataTable component
   function processScheduledSlotsForTable(
     scheduledSlots: ProcessedScheduledSlot[],
     eventId: string
   ): (string | number | JSX.Element)[][] {
-  
-    const { token } = useAuth();
-    const getWarningSymbol = (fieldName: string) => {
-        WarningsCounter.count=WarningsCounter.count+1;
-        return `⚠️ ${fieldName}`;
-    };
-    WarningsCounter.count = 0;
-    
-    const queryClient = useQueryClient();
-    const rows = scheduledSlots.map((ss, i) => {
-      let firstName=ss.firstName;
-      //Warning sign next to name works, need to fix warnings count and create red component for warning count and add to main event page as well.
-      if (typeof ss.firstName === "undefined") {
-      firstName = getWarningSymbol(firstName);
-    } else if (typeof ss.lastName === "undefined") {
-       firstName = getWarningSymbol(firstName);
-    } else if (typeof ss.timeSlot === "undefined") {
-       firstName = getWarningSymbol(firstName);
-    } else if (ss.participantType === "Driver") {
-       firstName = getWarningSymbol(firstName);
-    } else if (typeof ss.phoneNumber === "undefined") {
-       firstName = getWarningSymbol(firstName);
-    } else if (typeof ss.email === "undefined") {
-       firstName = getWarningSymbol(firstName);
-    }
+  const { token } = useAuth();
+  const getWarningSymbol = (fieldName: string) => {
+    return `⚠️ ${fieldName}`;
+  };
+  const queryClient = useQueryClient();
+  const rows = scheduledSlots.map((ss, i) => {
+    let firstName = ss.firstName;
+    //Warning sign next to name works, need to fix warnings count and create red component for warning count and add to main event page as well.
 
+    if (
+      typeof ss.firstName === "undefined" ||
+      typeof ss.lastName === "undefined" ||
+      typeof ss.timeSlot === "undefined" ||
+      ss.participantType === "Driver" ||
+      typeof ss.phoneNumber === "undefined" ||
+      typeof ss.email === "undefined"
+    ) {
+      firstName = getWarningSymbol(firstName);
+    }
     return [
       ss.id,
       i + 1,
@@ -235,65 +319,63 @@ export const VolunteersTable: React.FC<{
       ss.lastName,
       ss.timeSlot,
       ss.participantType,
-        /* Confirmed Checkbox */
-        <HttpCheckbox
-          checked={ss.confirmed}
-          mutationFn={applyPatch(
-            `/api/volunteers/confirm/${ss.id}`,
-            { newConfirmationStatus: !ss.confirmed },
-            token as string
-          )}
-          onSuccess={() => {
-            const toastMessage = `${ss.firstName} ${ss.lastName} ${
-              ss.confirmed ? "unconfirmed" : "confirmed"
-            }`;
-            queryClient.invalidateQueries(
-              VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
-            );
-            toastNotify(toastMessage, "success");
-          }}
-          onError={() => toastNotify("Unable to confirm volunteer", "failure")}
-        />,
-        /* Not Going Checkbox */
-        <HttpCheckbox
-          checked={ss.cantCome}
-          mutationFn={applyPatch(
-            `/api/volunteers/going/${ss.id}`,
-            { newGoingStatus: !ss.cantCome },
-            token as string
-          )}
-          onSuccess={() => {
-            const toastMessage = `${ss.firstName} ${ss.lastName} ${
-              ss.cantCome ? "is able to volunteer" : "is unable to volunteer"
-            }`;
-            queryClient.invalidateQueries(
-              VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
-            );
-            toastNotify(toastMessage, "success");
-          }}
-          onError={() =>
-            toastNotify("Unable to modify availability", "failure")
-          }
-        />,
-        ss.specialGroup ?? "N/A",
-        typeof ss.totalDeliveries === "number" ? ss.totalDeliveries : "N/A",
-        /* Contact Modal */
-        <ContactPopup phoneNumber={ss.phoneNumber} email={ss.email} />,
-        <EditVolunteerPopup
-          id={ss.id}
-          email={ss.email}
-          phoneNumber={ss.phoneNumber}
-          firstName={ss.firstName}
-          lastName={ss.lastName}
-          participantType={ss.participantType}
-          onEditSuccess={() => {
-            queryClient.invalidateQueries(
-              VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
-            );
-          }}
-        />,
-      ];
-    });
+      /* Confirmed Checkbox */
+      <HttpCheckbox
+        checked={ss.confirmed}
+        mutationFn={applyPatch(
+          `/api/volunteers/confirm/${ss.id}`,
+          { newConfirmationStatus: !ss.confirmed },
+          token as string
+        )}
+        onSuccess={() => {
+          const toastMessage = `${ss.firstName} ${ss.lastName} ${
+            ss.confirmed ? "unconfirmed" : "confirmed"
+          }`;
+          queryClient.invalidateQueries(
+            VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
+          );
+          toastNotify(toastMessage, "success");
+        }}
+        onError={() => toastNotify("Unable to confirm volunteer", "failure")}
+      />,
+      /* Not Going Checkbox */
+      <HttpCheckbox
+        checked={ss.cantCome}
+        mutationFn={applyPatch(
+          `/api/volunteers/going/${ss.id}`,
+          { newGoingStatus: !ss.cantCome },
+          token as string
+        )}
+        onSuccess={() => {
+          const toastMessage = `${ss.firstName} ${ss.lastName} ${
+            ss.cantCome ? "is able to volunteer" : "is unable to volunteer"
+          }`;
+          queryClient.invalidateQueries(
+            VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
+          );
+          toastNotify(toastMessage, "success");
+        }}
+        onError={() => toastNotify("Unable to modify availability", "failure")}
+      />,
+      ss.specialGroup ?? "N/A",
+      typeof ss.totalDeliveries === "number" ? ss.totalDeliveries : "N/A",
+      /* Contact Modal */
+      <ContactPopup phoneNumber={ss.phoneNumber} email={ss.email} />,
+      <EditVolunteerPopup
+        id={ss.id}
+        email={ss.email}
+        phoneNumber={ss.phoneNumber}
+        firstName={ss.firstName}
+        lastName={ss.lastName}
+        participantType={ss.participantType}
+        onEditSuccess={() => {
+          queryClient.invalidateQueries(
+            VOLUNTEERS_FOR_EVENT_QUERY_KEYS.fetchVolunteersForEvent(eventId)
+          );
+        }}
+      />,
+    ];
+  });
     return rows;
 
   }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -29,7 +29,6 @@ export interface ProcessedScheduledSlot {
   email: string;
   phoneNumber: string;
   specialGroup: string | null;
-  countOfEventsCompleted:number;
 }
 
 export interface ProcessedDriver {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
-        "dotenv": "^16.0.3",
+        "dotenv": "^16.4.5",
         "express": "^4.18.2",
         "express-async-handler": "^1.2.0",
         "jsonwebtoken": "^8.5.1",
@@ -721,11 +721,14 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -2580,9 +2583,9 @@
       "dev": true
     },
     "dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
-    "dotenv": "^16.0.3",
+    "dotenv": "^16.4.5",
     "express": "^4.18.2",
     "express-async-handler": "^1.2.0",
     "jsonwebtoken": "^8.5.1",

--- a/server/httpUtils/airtable.ts
+++ b/server/httpUtils/airtable.ts
@@ -91,7 +91,7 @@ async function airtableFetch<T>({
 
     if (!resp.ok) {
       const data = await resp.json();
-      logger.error(`Airtable error ${JSON.stringify(data)}`);
+      logger.error(`Airtable error ${data}`);
       return { kind: "error", error: data };
     }
 

--- a/server/routes/volunteers.ts
+++ b/server/routes/volunteers.ts
@@ -85,7 +85,6 @@ function processScheduledSlots(
       email: ss.fields["Email"] ? ss.fields["Email"][0] : "None",
       phoneNumber: ss.fields["Phone Formula"] || "None",
       specialGroup: ss.fields["Volunteer Group (for MAKE)"] || null,
-      countOfEventsCompleted:ss.fields["Count of Events Completed"],
     };
 
     const isDriver = participantType.includes("Driver");
@@ -131,8 +130,7 @@ router.route("/api/volunteers/").get(
       `&fields=Volunteer Status` +
       `&fields=Can't Come` +
       `&fields=Email` +
-      `&fields=Volunteer Group (for MAKE)`+
-      `&fields=Count of Events Completed`;
+      `&fields=Volunteer Group (for MAKE)`;
 
     const scheduledSlots = await airtableGET<ScheduledSlot>({ url: url });
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -85,7 +85,6 @@ export interface ScheduledSlot {
   "Phone Formula": string | undefined;
   Email: string[] | undefined;
   "Volunteer Group (for MAKE)": string | undefined;
-  "Count of Events Completed":number;
 }
 
 export interface ProcessedScheduledSlot {
@@ -101,7 +100,6 @@ export interface ProcessedScheduledSlot {
   email: string;
   phoneNumber: string;
   specialGroup: string | null;
-  countOfEventsCompleted:number;
 }
 
 export interface Driver {


### PR DESCRIPTION
## Description of this change
Added small warning symbol next to first names if missing any info (i.e any of the scheduledslots types were undefined). Additionally added an export function that keeps count of these warnings. Used this function to add a counter on the top of each event in red
## Screenshots (for UI changes - otherwise delete this section)
### Before this PR:
\
<img width="1612" alt="Screenshot 2024-07-31 at 4 07 34 PM" src="https://github.com/user-attachments/assets/1bbfc087-53c1-40c6-bb7b-3808b844281e">
<img width="1549" alt="Screenshot 2024-07-31 at 4 08 23 PM" src="https://github.com/user-attachments/assets/c62930e8-6d6b-4ae7-9d64-dd49a05e9a63">
### After this PR:
\
<img width="1638" alt="Screenshot 2024-07-31 at 4 06 30 PM" src="https://github.com/user-attachments/assets/a7ce15de-1bbe-4ef0-b6bf-310359183e76">
<img width="1552" alt="Screenshot 2024-07-31 at 4 06 53 PM" src="https://github.com/user-attachments/assets/772c3eb0-d1d2-4647-8cd9-9ad32c6ffbe9">
(warnings are from changing if statement from if typeof participanType is undefined to if participantType is driver. Pull request will not show any warnings)
