### PR TITLE
Added year to event date display throughout

### DIFF
--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -91,10 +91,10 @@ function processGeneralEventData(event: AirtableRecord<Event>): ProcessedEvent {
   return {
     id: event.id,
     date: eventDate,
-    dateDisplay:
+    dateDisplay: 
       eventDate.toLocaleDateString("en-US", optionsDay) +
       getOrdinal(new Date(event.fields["Start Time"]).getDate()) + ", " +
-      eventDate.toLocaleDateString("en-US", optionsYear), // start day in Weekday, Month Day format
+      eventDate.toLocaleDateString("en-US", optionsYear), // start day in Weekday, Month Day, Year format
 
     time: eventDate.toLocaleString("en-US", optionsTime), // start time in HH:MM AM/PM format
     mainLocation: event.fields["Pickup Address"]

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -42,6 +42,10 @@ function processGeneralEventData(event: AirtableRecord<Event>): ProcessedEvent {
     day: "numeric",
     timeZone: "America/New_York",
   } as const;
+  const optionsYear = {
+    year: "numeric",
+    timeZone: "America/New_York",
+  } as const;
   const optionsTime = {
     hour: "numeric",
     minute: "numeric",
@@ -89,7 +93,8 @@ function processGeneralEventData(event: AirtableRecord<Event>): ProcessedEvent {
     date: eventDate,
     dateDisplay:
       eventDate.toLocaleDateString("en-US", optionsDay) +
-      getOrdinal(new Date(event.fields["Start Time"]).getDate()), // start day in Weekday, Month Day format
+      getOrdinal(new Date(event.fields["Start Time"]).getDate()) + ", " +
+      eventDate.toLocaleDateString("en-US", optionsYear), // start day in Weekday, Month Day format
 
     time: eventDate.toLocaleString("en-US", optionsTime), // start time in HH:MM AM/PM format
     mainLocation: event.fields["Pickup Address"]


### PR DESCRIPTION
## Description of this change
Added year to event date display. Closes issue #171. Makes it clear for all cases the year of event, including historical dates. 
## Screenshots (for UI changes - otherwise delete this section)
### Before this PR:
![image](https://github.com/user-attachments/assets/64a1dee9-9ce8-40b5-ac88-6ee2372fe5de)
![image](https://github.com/user-attachments/assets/ff75b9f0-0f4d-48e0-bdec-0aca28f46f9a)

### After this PR:
![image](https://github.com/user-attachments/assets/24dfed83-d315-47ea-af22-bac9c893fef4)
![image](https://github.com/user-attachments/assets/5ca2b4c8-e27c-42e3-b9c8-5aeb1b8bcdd7)

## Checklist
- [x] Added link to existing Issue (created issue if there wasn't one already)
- [x] Added screenshots before/after for UI changes
- [x] PR is from branch pushed to this repo so that it will trigger Railway PR deployment
- [x] Code follows the style of this project
