### PR TITLE
Fixed participant counts not counting unconfirmed special event volunteers 

### DIFF
--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -205,9 +205,9 @@ router.route("/api/events").get(
       for (const se of specialEventsForThisGeneralEvent) {
         processedGeneralEvent.numSpecialGroups += 1;
         processedGeneralEvent.numOnlyPackers +=
-          se.fields["Only Distributor Count"] || 0;
+          se.fields["Only Distributor Count Including Unconfirmed"] || 0;
         processedGeneralEvent.numOnlyDrivers +=
-          se.fields["Only Driver Count"] || 0;
+          se.fields["Only Driver Count Including Unconfirmed"] || 0;
         processedGeneralEvent.numDrivers +=
           se.fields["Total Count of Drivers for Event"] || 0;
         processedGeneralEvent.numPackers +=
@@ -215,7 +215,7 @@ router.route("/api/events").get(
         processedGeneralEvent.numTotalParticipants +=
           se.fields["Total Count of Volunteers for Event"] || 0;
         processedGeneralEvent.numBothDriversAndPackers +=
-          se.fields["Driver and Distributor Count"] || 0;
+          se.fields["Driver and Distributor Count Including Unconfirmed"] || 0;
         processedGeneralEvent.scheduledSlots =
           processedGeneralEvent.scheduledSlots.concat(
             se.fields["📅 Scheduled Slots"] || []


### PR DESCRIPTION
## Description of this change
Issue[#177 ](https://github.com/grassrootsgrocery/admin-portal/issues/177) was because unconfirmed special event volunteers were not being included in the "Drivers Only", "Packers Only", or "Driving & Packing" counts. For instance, the "Drivers Only" total was being calculated by summing the "Only Driver Count Including Unconfirmed" property for the general event, with the "Only Driver Count" property (which only counts confirmed drivers) of each special event.

I fixed this by updating the properties of the special events that were being summed to be the properties that included unconfirmed volunteers: I replaced "Only Driver Count" with "Only Driver Count Including Unconfirmed", "Only Distributor Count" with "Only Distributor Count Including Unconfirmed", and "Driver and Distributor Count" with "Driver and Distributor Count Including Unconfirmed".



## Screenshots (for UI changes - otherwise delete this section)
### Before this PR:
<img width="861" alt="Screenshot 2024-09-24 at 10 34 54 PM" src="https://github.com/user-attachments/assets/e19e15b7-1b91-48b8-9ee7-8b5ca91dda7c">


### After this PR:
<img width="898" alt="Screenshot 2024-09-24 at 10 10 38 PM" src="https://github.com/user-attachments/assets/4486a9ea-8a6d-4db3-a651-df1dc986bed4">

## Checklist
- [x] Added link to existing Issue (created issue if there wasn't one already)
- [x] Added screenshots before/after for UI changes
- [x] PR is from branch pushed to this repo so that it will trigger Railway PR deployment
- [x] Code follows the style of this project
