### PR TITLE
Include guest counts into total participant and packer counts

### DIFF
--- a/client/src/pages/Events/EventCard.tsx
+++ b/client/src/pages/Events/EventCard.tsx
@@ -11,6 +11,7 @@ interface Props {
   participants: number;
   drivers: number;
   packers: number;
+  guests: number;
 }
 
 export const EventCard: React.FC<Props> = ({
@@ -21,6 +22,7 @@ export const EventCard: React.FC<Props> = ({
   eventId,
   drivers,
   packers,
+  guests,
 }) => {
   // Tailwind classes
   const label = "text-sm md:text-base lg:text-xl";
@@ -68,7 +70,7 @@ export const EventCard: React.FC<Props> = ({
           </div>
           {/* Packers Count */}
           <div className="col-span-4 md:col-span-4 lg:col-span-1">
-            <h3 className={labelBold}>{packers}</h3>
+            <h3 className={labelBold}>{packers + guests}</h3>
           </div>
         </div>
 
@@ -78,7 +80,7 @@ export const EventCard: React.FC<Props> = ({
             <p className="text-sm md:text-base lg:text-xl">
               Total Participants
             </p>
-            <h3 className={labelBold}>{participants}</h3>
+            <h3 className={labelBold}>{participants + guests} ({guests} guests)</h3>
           </div>
           <div className="flex grow items-center lg:justify-end">
             <Link to={`/events/${eventId}`}>

--- a/client/src/pages/Events/Events.tsx
+++ b/client/src/pages/Events/Events.tsx
@@ -113,6 +113,7 @@ export function Events() {
                 participants={event.numTotalParticipants}
                 drivers={event.numDrivers}
                 packers={event.numPackers}
+                guests={event.numGuests}
               />
             );
           })}

--- a/client/src/pages/ViewEvent/ViewEvent.tsx
+++ b/client/src/pages/ViewEvent/ViewEvent.tsx
@@ -136,16 +136,16 @@ export const ViewEvent = () => {
               value={event.numPackers + event.numGuests}
             />
             <HeaderValueDisplay
-              header="# Driving & Packing"
-              value={event.numBothDriversAndPackers}
+              header="Expected Sign-ins"
+              value={event.numTotalParticipants}
             />
             <HeaderValueDisplay
               header="Drivers Only"
               value={event.numOnlyDrivers}
             />
             <HeaderValueDisplay
-              header="Packers Only"
-              value={event.numOnlyPackers + event.numGuests}
+              header="Drivers also Packing"
+              value={event.numBothDriversAndPackers}
             />
             <HeaderValueDisplay
               header="# of Special Groups"

--- a/client/src/pages/ViewEvent/ViewEvent.tsx
+++ b/client/src/pages/ViewEvent/ViewEvent.tsx
@@ -108,7 +108,7 @@ export const ViewEvent = () => {
           />
           <HeaderValueDisplay
             header="Total Participants"
-            value={event.numTotalParticipants}
+            value={`${event.numTotalParticipants + event.numGuests} (${event.numGuests} guests)`}
           />
         </div>
         <div className="h-12" />
@@ -133,7 +133,7 @@ export const ViewEvent = () => {
             </div>
             <HeaderValueDisplay
               header="Total # of Packers"
-              value={event.numPackers}
+              value={event.numPackers + event.numGuests}
             />
             <HeaderValueDisplay
               header="# Driving & Packing"
@@ -145,7 +145,7 @@ export const ViewEvent = () => {
             />
             <HeaderValueDisplay
               header="Packers Only"
-              value={event.numOnlyPackers}
+              value={event.numOnlyPackers + event.numGuests}
             />
             <HeaderValueDisplay
               header="# of Special Groups"

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -14,6 +14,7 @@ export interface ProcessedEvent {
   scheduledSlots: string[];
   supplierId: string;
   allEventIds: string[];
+  numGuests: number;
 }
 
 export interface ProcessedScheduledSlot {

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -87,6 +87,9 @@ function processGeneralEventData(event: AirtableRecord<Event>): ProcessedEvent {
 
   const numDriversAndPackers =
     event.fields["Driver and Distributor Count Including Unconfirmed"] || 0; // all driver and distr participants for event
+ 
+  const numGuests =
+    Number(event.fields["totalGuestsOnDate"] || 0); // all guests for event
 
   return {
     id: event.id,
@@ -112,6 +115,7 @@ function processGeneralEventData(event: AirtableRecord<Event>): ProcessedEvent {
       ? event.fields.Supplier[0]
       : "No supplier",
     allEventIds: [event.id],
+    numGuests: numGuests,
   };
 }
 
@@ -172,7 +176,8 @@ router.route("/api/events").get(
       `&fields=Total Count of Volunteers for Event` + // Total Participants
       `&fields=Special Event` + // isSpecialEvent
       `&fields=Supplier` +
-      `&fields=📅 Scheduled Slots`; //Scheduled slots -> list of participants for event
+      `&fields=📅 Scheduled Slots` + //Scheduled slots -> list of participants for event
+      `&fields=totalGuestsOnDate`; 
 
     const futureEventsAirtableResp = await airtableGET<Event>({ url: url });
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -44,6 +44,7 @@ export interface Event {
   "Special Event": boolean | undefined;
   Supplier: string[] | undefined;
   "📅 Scheduled Slots": string[] | undefined;
+  "totalGuestsOnDate": number | undefined;
 }
 
 export interface TextAutomation {
@@ -71,6 +72,7 @@ export interface ProcessedEvent {
   scheduledSlots: string[];
   supplierId: string;
   allEventIds: string[];
+  numGuests: number;
 }
 
 export interface ScheduledSlot {


### PR DESCRIPTION
## Description of this change
Closes issue #143.  Add guest count to event pages. This is important to give a more accurate view of the number of people attending since there are many guests that come to events.
## Screenshots (for UI changes - otherwise delete this section)
### Before this PR:
![image](https://github.com/user-attachments/assets/74b8d0a6-8f54-40bf-8120-82d4effead16)
![image](https://github.com/user-attachments/assets/b153216e-488d-4960-93d4-ba5dbe52dd53)

### After this PR:
![image](https://github.com/user-attachments/assets/da055de3-5575-4ecc-849c-96467a29a358)
![image](https://github.com/user-attachments/assets/020aaee8-d647-4793-9daa-25310e03d8bf)

## Checklist
- [x] Added link to existing Issue (created issue if there wasn't one already)
- [x] Added screenshots before/after for UI changes
- [x] PR is from branch pushed to this repo so that it will trigger Railway PR deployment
- [x] Code follows the style of this project